### PR TITLE
Optimize downloads

### DIFF
--- a/updatesnap/updatesnap.py
+++ b/updatesnap/updatesnap.py
@@ -66,7 +66,7 @@ def print_summary(data):
         printed_line = True
         print(f"{entry['name']} current version: {entry['version'][0]} ({entry['version'][1]}); available updates:")
         for update in entry["updates"]:
-            print(f"    {update['name']} (tagget at {update['date']})")
+            print(f"    {update['name']} (tagged at {update['date']})")
 
 
 parser = argparse.ArgumentParser(prog="Update Snap",


### PR DESCRIPTION
This MR greatly reduces the number of pages to download from github/gitlab by stopping as soon as the current tag has been found, and avoiding downloading data from tags that don't match the part format.