### PR TITLE
Add no-imports installer

### DIFF
--- a/updatesnap/README.md
+++ b/updatesnap/README.md
@@ -4,14 +4,11 @@ A simple script that checks a snapcraft yaml file and shows possible new version
 
 ## Installing
 
-As usual, just doing
+Just run:
 
-    python3 -m pip install .
+    sudo install.sh
 
-will install it in your user. Of course, it is mandatory to have $HOME/.local/bin in the PATH to
-be able to run it.
-
-Before installing, be sure to fully delete the folders 'build' and 'udpatesnap.egg-info'.
+will install it at /usr/local/bin
 
 ## Using it
 

--- a/updatesnap/install.sh
+++ b/updatesnap/install.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+./mix_modules.py updatesnap.py /usr/local/bin

--- a/updatesnap/mix_modules.py
+++ b/updatesnap/mix_modules.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+
+base_file = sys.argv[1]
+destination = os.path.join(sys.argv[2], base_file)
+
+def load_module(name, path):
+    global modules
+
+    imports = []
+    content = ""
+    with open(path, "r") as ifile:
+        for line in ifile:
+            if line.startswith("import ") or line.startswith("from "):
+                imports.append(line.strip())
+                continue
+            content += line
+    modules[name] = {"imports": imports, "content": content}
+
+def add_import(ip):
+    global imports
+
+    if ip in imports:
+        return
+    imports.append(ip)
+
+modules = {}
+load_module("SnapModule.snapmodule", "SnapModule/snapmodule.py")
+
+imports = []
+
+contents = ""
+
+with open(base_file, "r") as ifile:
+    for line in ifile:
+        if line.strip() == "from SnapModule.snapmodule import Snapcraft":
+            for ip in modules["SnapModule.snapmodule"]["imports"]:
+                add_import(ip)
+            contents += modules["SnapModule.snapmodule"]["content"]
+            continue
+        if line.startswith("import ") or (line.startswith("from ")):
+            add_import(line.strip())
+            continue
+
+with open(destination, "w") as ofile:
+    ofile.write("#!/usr/bin/env python3\n\n")
+    for ip in imports:
+        ofile.write(f"{ip}\n")
+    ofile.write("\n")
+    ofile.write(contents)
+    ofile.write("\n")
+    with open(base_file, "r") as ifile:
+        for line in ifile:
+            if line.strip().startswith("#"):
+                continue
+            if line.startswith("import ") or line.startswith("from "):
+                continue
+            ofile.write(line)
+
+os.chmod(destination, 0o755 )


### PR DESCRIPTION
The new install.sh file will mix the main program with the local modules, to avoid needing to use venvs and other things that would be complex in a CI environment.

This allows to use the same SnapModule import in several utilities.