### PR TITLE
Remove header junk that would be committed as part of the new snapcraft.yaml

### DIFF
--- a/updatesnap/updatesnapyaml.py
+++ b/updatesnap/updatesnapyaml.py
@@ -104,13 +104,10 @@ def main():
         version_data = manager_yaml.get_part_element(part['name'], 'source-tag:')
         if not version_data:
             continue
-        print(f"Updating '{part['name']}' from version '{part['version'][0]}'"
-            " to version '{part['updates'][0]['name']}'")
         version_data['data'] = f"source-tag: '{part['updates'][0]['name']}'"
         has_update = True
 
     if has_update:
-        print("\n\n")
         print(manager_yaml.get_yaml())
     else:
         print("No updates available")


### PR DESCRIPTION
When these statements are printed, they add to the snapcraft.yaml that is then committed in other repos with updatesnapyaml.py.

For example, with these print statements, we see some additional header stuff that is not needed.

![image](https://user-images.githubusercontent.com/12970280/231265353-cb379bf6-3954-4ecd-a398-e09bec0e6196.png)

Here's an example PR: https://github.com/ubuntu/gnome-calculator/pull/11/files