### PR TITLE
Use STDERR for message output

### DIFF
--- a/updatesnap/SnapModule/snapmodule.py
+++ b/updatesnap/SnapModule/snapmodule.py
@@ -25,7 +25,7 @@ class Colors:
 
 
     def clear_line(self):
-        print(self.clearline, end="\r") # clear the line
+        print(self.clearline, end="\r", file=sys.stderr) # clear the line
 
 class ProcessVersion:
 
@@ -40,11 +40,11 @@ class ProcessVersion:
             return
         if part != self._last_part:
             print(f"Part: {self._colors.note}{part}{self._colors.reset}"
-                  f"{f' ({source})' if source else ''}")
+                  f"{f' ({source})' if source else ''}", file=sys.stderr)
             self._last_part = part
         if message is not None:
-            print("  " + message, end="")
-            print(self._colors.reset)
+            print("  " + message, end="", file=sys.stderr)
+            print(self._colors.reset, file=sys.stderr)
 
     def _read_number(self, text):
         number = 0
@@ -123,7 +123,7 @@ class GitClass(ProcessVersion):
 
     def _read_uri(self, uri):
         if not self._silent:
-            print(f"Asking URI {uri}     ", end="\r")
+            print(f"Asking URI {uri}     ", end="\r", file=sys.stderr)
         while True:
             try:
                 if (self._user is not None) and (self._token is not None):
@@ -134,7 +134,7 @@ class GitClass(ProcessVersion):
                 break
             except:
                 if not self._silent:
-                    print(f"Retrying URI {uri}     ", end="\r")
+                    print(f"Retrying URI {uri}     ", end="\r", file=sys.stderr)
                 time.sleep(1)
         return response
 
@@ -148,7 +148,7 @@ class GitClass(ProcessVersion):
             if response.status_code != 200:
                 if not self._silent:
                     print(f"{self._colors.critical}Status code {response.status_code} "
-                          f"when asking for {uri}{self._colors.reset}")
+                          f"when asking for {uri}{self._colors.reset}", file=sys.stderr)
                 return []
             headers = response.headers
             data = response.json()
@@ -175,7 +175,7 @@ class GitClass(ProcessVersion):
         response = self._read_uri(uri)
         if response.status_code != 200:
             print(f"{self._colors.critical}Status code {response.status_code} "
-                  f"when asking for {uri}{self._colors.reset}")
+                  f"when asking for {uri}{self._colors.reset}", file=sys.stderr)
             return None
         headers = response.headers
         data = response.json()
@@ -190,12 +190,12 @@ class GitClass(ProcessVersion):
         elements = uri.path.split("/")
         if (uri.scheme != 'http') and (uri.scheme != 'https') and (uri.scheme != 'git'):
             print(f"{self._colors.critical}Unrecognized protocol in repository "
-                  f"{repository}{self._colors.reset}")
+                  f"{repository}{self._colors.reset}", file=sys.stderr)
             return None
         elements = uri.path.split("/")
         if len(elements) < min_elements:
             print(f"{self._colors.critical}Invalid uri format for repository "
-                  f"{repository}{self._colors.reset}")
+                  f"{repository}{self._colors.reset}", file=sys.stderr)
             return None
         return uri
 
@@ -379,7 +379,7 @@ class Snapcraft(ProcessVersion):
         elif backend == 'gitlab':
             self._gitlab.set_secret(key, value)
         else:
-            print(f"Unknown backend: {backend}")
+            print(f"Unknown backend: {backend}", file=sys.stderr)
 
 
     def load_local_file(self, filename = None):
@@ -391,10 +391,10 @@ class Snapcraft(ProcessVersion):
             if not os.path.exists(filename_tmp):
                 filename_tmp = os.path.join(filename, "snap", "snapcraft.yaml")
                 if not os.path.exists(filename_tmp):
-                    print(f"No snapcraft file found at folder {filename}")
+                    print(f"No snapcraft file found at folder {filename}", file=sys.stderr)
             filename = filename_tmp
         if os.path.exists(filename):
-            print(f"Opening file {filename}")
+            print(f"Opening file {filename}", file=sys.stderr)
             with open(filename, "r") as file_data:
                 data = file_data.read()
             self._open_yaml_file_with_extensions(data, "updatesnap")
@@ -541,14 +541,14 @@ class Snapcraft(ProcessVersion):
             ((not 'source-type' in data) or (data['source-type'] != 'git'))):
             self._print_message(part, f"{self._colors.critical}Source is neither http:// "
                                       f"nor git://{self._colors.reset}", source = source)
-            print()
+            print("", file=sys.stderr)
             return part_data
 
         if (not source.endswith('.git')) and ((not 'source-type' in data)
             or (data['source-type'] != 'git')):
             self._print_message(part, f"{self._colors.warning}Source is not a GIT "
                                       f"repository{self._colors.reset}", source = source)
-            print()
+            print("", file=sys.stderr)
             return part_data
 
         if 'savannah' in source:
@@ -557,7 +557,7 @@ class Snapcraft(ProcessVersion):
                 self._print_message(part, f"{self._colors.warning}Savannah repositories "
                                           f"not supported{self._colors.reset}", source = source)
                 if not self._silent:
-                    print()
+                    print("", file=sys.stderr)
                 return part_data
 
         self._print_message(part, None, source = source)
@@ -584,7 +584,7 @@ class Snapcraft(ProcessVersion):
                                       f"specific tag{self._colors.reset}")
             self._print_last_tags(part, tags)
         if not self._silent:
-            print()
+            print("", file=sys.stderr)
         return part_data
 
 

--- a/updatesnap/updatesnap.py
+++ b/updatesnap/updatesnap.py
@@ -53,7 +53,7 @@ def print_summary(data):
         if entry is None:
             continue
         if printed_line:
-            print()
+            print("", file=sys.stderr)
             printed_line = False
         if entry["missing_format"]:
             print(f"{entry['name']}: needs version format definition.")
@@ -92,7 +92,7 @@ def main():
     if argument_list.r: # recursive
         if (argument_list.folder.startswith("http://") or
             argument_list.folder.startswith("https://")):
-            print("-r parameter can't be used with http or https. Aborting.")
+            print("-r parameter can't be used with http or https. Aborting.", file=sys.stderr)
             sys.exit(-1)
         retval = []
         for folder in os.listdir(argument_list.folder):
@@ -107,7 +107,7 @@ def main():
         else:
             response = requests.get(argument_list.folder)
             if not response:
-                print(f"Failed to get the file {argument_list.folder}: {response.status_code}")
+                print(f"Failed to get the file {argument_list.folder}: {response.status_code}", file=sys.stderr)
                 sys.exit(-1)
             retval = process_data(response.content.decode('utf-8'), argument_list)
     print_summary(retval)

--- a/updatesnap/updatesnapyaml.py
+++ b/updatesnap/updatesnapyaml.py
@@ -67,7 +67,7 @@ def main():
     arguments = parser.parse_args(sys.argv[1:])
 
     if arguments.project == '.':
-        print('A project URI is mandatory')
+        print('A project URI is mandatory', file=sys.stderr)
         sys.exit(-1)
 
     manager = ProjectManager(arguments.github_user, arguments.github_token)
@@ -77,7 +77,7 @@ def main():
     #branch = manager.get_working_branch(arguments.project)
     data = manager.get_yaml_file(arguments.project)
     if not data:
-        print('Failed to get the snapcraft.yaml file.')
+        print('Failed to get the snapcraft.yaml file.', file=sys.stderr)
         sys.exit(-1)
     contents = base64.b64decode(data['content']).decode('utf-8')
 
@@ -92,7 +92,7 @@ def main():
     parts = snap.process_parts()
 
     if len(parts) == 0:
-        print("The snapcraft.yaml file has no parts.")
+        print("The snapcraft.yaml file has no parts.", file=sys.stderr)
         sys.exit(0) # no parts
 
     has_update = False
@@ -105,15 +105,16 @@ def main():
         if not version_data:
             continue
         print(f"Updating '{part['name']}' from version '{part['version'][0]}'"
-            " to version '{part['updates'][0]['name']}'")
+            " to version '{part['updates'][0]['name']}'", file=sys.stderr)
         version_data['data'] = f"source-tag: '{part['updates'][0]['name']}'"
         has_update = True
 
     if has_update:
-        print("\n\n")
         print(manager_yaml.get_yaml())
+        sys.exit(0)
     else:
-        print("No updates available")
+        print("No updates available", file=sys.stderr)
+        sys.exit(-1)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This change ensures that all the messages are sent to STDERR, thus leaving STDOUT for the output itself.

Fix https://github.com/ubuntu/desktop-snaps/issues/27