### PR TITLE
Add no-9x-minors option

### DIFF
--- a/updatesnap/README.md
+++ b/updatesnap/README.md
@@ -137,6 +137,9 @@ The available extra tokens are:
   current version will be ignored.
 * same-minor: if specified as TRUE, version numbers with a different minor value than the
   current version will be ignored.
+* no-9x-minors: if specified as TRUE, version numbers with a minor value equal or
+  greater than 90 will be ignored. Useful for projects that use these minor numbers
+  as "prelude" to a new major version.
 * no-9x-revisions: if specified as TRUE, version numbers with a revision value equal or
   greater than 90 will be ignored. Useful for projects that use these revision numbers
   as "prelude" to a new minor version.

--- a/updatesnap/SnapModule/snapmodule.py
+++ b/updatesnap/SnapModule/snapmodule.py
@@ -116,7 +116,8 @@ class ProcessVersion:
             return None
         if self._checkopt("no-9x-revisions", entry_format) and (revision >= 90):
             return None
-
+        if self._checkopt("no-9x-minors", entry_format) and (minor >= 90):
+            return None
         return version
 
 

--- a/updatesnap/test_yaml.py
+++ b/updatesnap/test_yaml.py
@@ -90,6 +90,22 @@ class TestYAMLfiles(unittest.TestCase):
         manager_yaml = ManageYAML(datafile)
         assert manager_yaml.get_yaml() == datafile
 
+    def test_no_9x_revisions(self):
+        obj = ProcessVersion(silent=True)
+        entry_format = {"format":"%M.%m.%R", "no-9x-revisions": True}
+        version = obj._get_version("testpart", "3.8.92", entry_format, False)
+        assert version is None
+        version = obj._get_version("testpart", "3.8.32", entry_format, False)
+        assert str(version) == "3.8.32"
+
+    def test_no_9x_minors(self):
+        obj = ProcessVersion(silent=True)
+        entry_format = {"format":"%M.%m.%R", "no-9x-minors": True}
+        version = obj._get_version("testpart", "3.97.1", entry_format, False)
+        assert version is None
+        version = obj._get_version("testpart", "3.45.1", entry_format, False)
+        assert str(version) == "3.45.1"
+
 
     def test_ignore_odd_minor(self):
         # pylint: disable=protected-access


### PR DESCRIPTION
This option allows to ignore entries with versions in the format XX.9y.ZZ, which are usually used as pre-releases for a version with a new major number.