### PR TITLE
Remove failiure on no updates available case

### DIFF
--- a/updatesnap/updatesnapyaml.py
+++ b/updatesnap/updatesnapyaml.py
@@ -111,7 +111,7 @@ def main():
         sys.exit(0)
     else:
         print("No updates available", file=sys.stderr)
-        sys.exit(-1)
+        sys.exit(0)
 
 if __name__ == "__main__":
     main()

--- a/updatesnap/updatesnapyaml.py
+++ b/updatesnap/updatesnapyaml.py
@@ -111,7 +111,6 @@ def main():
         sys.exit(0)
     else:
         print("No updates available", file=sys.stderr)
-        sys.exit(0)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This should make the no updates available case pass, instead of the workflow failure we currently see:
https://github.com/ubuntu/gnome-characters/actions/runs/4794758902/jobs/8528496346