### PR TITLE
Limit updatesnaptests

### DIFF
--- a/.github/workflows/updatesnaptests.yml
+++ b/.github/workflows/updatesnaptests.yml
@@ -1,6 +1,9 @@
-name: Pylint
+name: UpdateSnapTests
 
-on: [pull_request]
+on:
+  pull_request:
+    paths:
+      - 'updatesnap/**'
 
 jobs:
   build:


### PR DESCRIPTION
Now updatesnaptests is run only if there are changes on the updatesnaptests folder, because it's the only thing that it checks.