### PR TITLE
Fix error when part uses branches

### DIFF
--- a/updatesnap/test_yaml.py
+++ b/updatesnap/test_yaml.py
@@ -31,7 +31,7 @@ class TestYAMLfiles(unittest.TestCase):
             obj.set_secrets(secrets)
 
 
-    def _load_test_file(self, filepath, tags):
+    def _load_test_file(self, filepath, tags, branches = None):
         with open(os.path.join("tests", filepath), "r", encoding='utf-8') as datafile:
             data = datafile.read()
         while data[:-2] == "\n\n":
@@ -39,8 +39,10 @@ class TestYAMLfiles(unittest.TestCase):
 
         github_pose = GitPose()
         github_pose.set_tags(tags)
+        github_pose.set_branches(branches)
         gitlab_pose = GitPose()
         gitlab_pose.set_tags(tags)
+        gitlab_pose.set_branches(branches)
         snap = Snapcraft(True, github_pose, gitlab_pose)
         snap.load_external_data(data)
         return snap, data
@@ -171,6 +173,13 @@ class TestYAMLfiles(unittest.TestCase):
             assert found
 
 
+    def test_branches(self):
+        """ Check that using branches in a part instead of tags does work """
+        snap, _ = self._load_test_file("gnome-boxes-test1.yaml",
+                                              None,
+                                              get_gnome_boxes_branches())
+        snap.process_parts()
+
 
 class GitPose:
     """ Helper class. It emulates a GitClass class, to allow to test
@@ -188,16 +197,289 @@ class GitPose:
         self._tags = tags
 
     def set_branches(self, branches):
-        """ Sets the bramches that will be returned by this object when asked """
+        """ Sets the branches that will be returned by this object when asked """
         self._branches = branches
 
     def get_tags(self, source, current_tag = None, version_format = None):
         # pylint: disable=unused-argument
         """ Implements the get_tags() method of GitClass """
+        if self._tags is None:
+            return []
         if source in self._tags:
             return self._tags[source]
         return []
 
+    def get_branches(self, source):
+        """ Implements the get_branches() method of GitClass """
+        if self._branches is None:
+            return []
+        if source in self._branches:
+            return self._branches[source]
+        return []
+
+def get_gnome_boxes_branches():
+    """ Returns a plausible list of branches for several tests """
+    return {
+        "https://gitlab.com/libvirt/libvirt.git":
+        [
+            {'name': 'master', 'date': 0},
+            {'name': 'v0.10.2-maint', 'date': 0},
+            {'name': 'v0.8.3-maint', 'date': 0},
+            {'name': 'v0.9.11-maint', 'date': 0},
+            {'name': 'v0.9.12-maint', 'date': 0},
+            {'name': 'v0.9.6-maint', 'date': 0},
+            {'name': 'v1.0.0-maint', 'date': 0},
+            {'name': 'v1.0.1-maint', 'date': 0},
+            {'name': 'v1.0.2-maint', 'date': 0},
+            {'name': 'v1.0.3-maint', 'date': 0},
+            {'name': 'v1.0.4-maint', 'date': 0},
+            {'name': 'v1.0.5-maint', 'date': 0},
+            {'name': 'v1.0.6-maint', 'date': 0},
+            {'name': 'v1.1.0-maint', 'date': 0},
+            {'name': 'v1.1.1-maint', 'date': 0},
+            {'name': 'v1.1.2-maint', 'date': 0},
+            {'name': 'v1.1.3-maint', 'date': 0},
+            {'name': 'v1.1.4-maint', 'date': 0},
+            {'name': 'v1.2.0-maint', 'date': 0},
+            {'name': 'v1.2.1-maint', 'date': 0},
+            {'name': 'v1.2.10-maint', 'date': 0},
+            {'name': 'v1.2.11-maint', 'date': 0},
+            {'name': 'v1.2.12-maint', 'date': 0},
+            {'name': 'v1.2.13-maint', 'date': 0},
+            {'name': 'v1.2.14-maint', 'date': 0},
+            {'name': 'v1.2.15-maint', 'date': 0},
+            {'name': 'v1.2.16-maint', 'date': 0},
+            {'name': 'v1.2.17-maint', 'date': 0},
+            {'name': 'v1.2.18-maint', 'date': 0},
+            {'name': 'v1.2.19-maint', 'date': 0},
+            {'name': 'v1.2.2-maint', 'date': 0},
+            {'name': 'v1.2.20-maint', 'date': 0},
+            {'name': 'v1.2.21-maint', 'date': 0},
+            {'name': 'v1.2.3-maint', 'date': 0},
+            {'name': 'v1.2.4-maint', 'date': 0},
+            {'name': 'v1.2.5-maint', 'date': 0},
+            {'name': 'v1.2.6-maint', 'date': 0},
+            {'name': 'v1.2.7-maint', 'date': 0},
+            {'name': 'v1.2.8-maint', 'date': 0},
+            {'name': 'v1.2.9-maint', 'date': 0},
+            {'name': 'v1.3.0-maint', 'date': 0},
+            {'name': 'v1.3.1-maint', 'date': 0},
+            {'name': 'v1.3.2-maint', 'date': 0},
+            {'name': 'v1.3.3-maint', 'date': 0},
+            {'name': 'v1.3.4-maint', 'date': 0},
+            {'name': 'v1.3.5-maint', 'date': 0},
+            {'name': 'v2.0-maint', 'date': 0},
+            {'name': 'v2.1-maint', 'date': 0},
+            {'name': 'v2.2-maint', 'date': 0},
+            {'name': 'v3.0-maint', 'date': 0},
+            {'name': 'v3.2-maint', 'date': 0},
+            {'name': 'v3.7-maint', 'date': 0},
+            {'name': 'v4.1-maint', 'date': 0},
+            {'name': 'v4.10-maint', 'date': 0},
+            {'name': 'v4.2-maint', 'date': 0},
+            {'name': 'v4.3-maint', 'date': 0},
+            {'name': 'v4.4-maint', 'date': 0},
+            {'name': 'v4.5-maint', 'date': 0},
+            {'name': 'v4.6-maint', 'date': 0},
+            {'name': 'v4.7-maint', 'date': 0},
+            {'name': 'v4.8-maint', 'date': 0},
+            {'name': 'v4.9-maint', 'date': 0},
+            {'name': 'v5.0-maint', 'date': 0},
+            {'name': 'v5.1-maint', 'date': 0},
+            {'name': 'v5.1.0-maint', 'date': 0},
+            {'name': 'v5.2-maint', 'date': 0},
+            {'name': 'v5.3-maint', 'date': 0}],
+        "https://gitlab.gnome.org/GNOME/tracker.git":
+        [{'name': '34-build-failure-with-werror-format-security', 'date': 0},
+            {'name': 'abderrahim/build-fix', 'date': 0},
+            {'name': 'api-cleanup', 'date': 0},
+            {'name': 'configurable-bus-type', 'date': 0},
+            {'name': 'crawler-max-depth', 'date': 0},
+            {'name': 'data-provider-monitor-interface', 'date': 0},
+            {'name': 'decorator-memory-reduction', 'date': 0},
+            {'name': 'domain-ontologies', 'date': 0},
+            {'name': 'external-libstemmer', 'date': 0},
+            {'name': 'fix-version', 'date': 0},
+            {'name': 'follow-symlinks', 'date': 0},
+            {'name': 'fts-property-names-cleanup', 'date': 0},
+            {'name': 'fts4', 'date': 0},
+            {'name': 'functional-test-fixes-bug-696172', 'date': 0},
+            {'name': 'gdbus-porting', 'date': 0},
+            {'name': 'hashtable-ordering-2.1', 'date': 0},
+            {'name': 'jolla-upstreaming', 'date': 0},
+            {'name': 'master', 'date': 0},
+            {'name': 'maxcardinality-change-support', 'date': 0},
+            {'name': 'maxcardinality-change-support-rebased', 'date': 0},
+            {'name': 'media-art-detect', 'date': 0},
+            {'name': 'meson-final', 'date': 0},
+            {'name': 'miner-twitter', 'date': 0},
+            {'name': 'oscp', 'date': 0},
+            {'name': 'pdf-extractor-no-forks', 'date': 0},
+            {'name': 'ricotz/vala', 'date': 0},
+            {'name': 'rss-update', 'date': 0},
+            {'name': 'sam/README', 'date': 0},
+            {'name': 'sam/README-updates', 'date': 0},
+            {'name': 'sam/app-domains', 'date': 0},
+            {'name': 'sam/ci', 'date': 0},
+            {'name': 'sam/ci-docs', 'date': 0},
+            {'name': 'sam/ci-sanitize', 'date': 0},
+            {'name': 'sam/circular-dep-fix', 'date': 0},
+            {'name': 'sam/comment', 'date': 0},
+            {'name': 'sam/common-file-utils', 'date': 0},
+            {'name': 'sam/coverity-fix', 'date': 0},
+            {'name': 'sam/diagrams', 'date': 0},
+            {'name': 'sam/functional-tests-pep8', 'date': 0},
+            {'name': 'sam/index-file-sync', 'date': 0},
+            {'name': 'sam/index-mount-points', 'date': 0},
+            {'name': 'sam/index-mount-points-2', 'date': 0},
+            {'name': 'sam/info-fix', 'date': 0},
+            {'name': 'sam/introspection-fix', 'date': 0},
+            {'name': 'sam/meson-0.60', 'date': 0},
+            {'name': 'sam/miner-fs-ignore-non-files', 'date': 0},
+            {'name': 'sam/namespace-c++', 'date': 0},
+            {'name': 'sam/remove-libuuid', 'date': 0},
+            {'name': 'sam/run-uninstalled-fixes', 'date': 0},
+            {'name': 'sam/share-sandboxes', 'date': 0},
+            {'name': 'sam/show-debug', 'date': 0},
+            {'name': 'sam/slow-tests', 'date': 0},
+            {'name': 'sam/test-utils', 'date': 0},
+            {'name': 'sam/tracker-2.3-developer-experience', 'date': 0},
+            {'name': 'sam/tracker-3.0-functional-tests', 'date': 0},
+            {'name': 'sam/tracker-resource-avoid-invalid-sparql', 'date': 0},
+            {'name': 'sam/uncrustify', 'date': 0},
+            {'name': 'sam/web-overview', 'date': 0},
+            {'name': 'sam/website-docs', 'date': 0},
+            {'name': 'sam/website-link', 'date': 0},
+            {'name': 'sam/wiki-to-website', 'date': 0},
+            {'name': 'sparql-ontology-tree', 'date': 0},
+            {'name': 'subtree-crawling', 'date': 0},
+            {'name': 'tintou/doc-update', 'date': 0},
+            {'name': 'tracker-0.10', 'date': 0},
+            {'name': 'tracker-0.12', 'date': 0},
+            {'name': 'tracker-0.14', 'date': 0},
+            {'name': 'tracker-0.16', 'date': 0},
+            {'name': 'tracker-0.6', 'date': 0},
+            {'name': 'tracker-0.8', 'date': 0},
+            {'name': 'tracker-1.0', 'date': 0},
+            {'name': 'tracker-1.10', 'date': 0},
+            {'name': 'tracker-1.12', 'date': 0},
+            {'name': 'tracker-1.2', 'date': 0},
+            {'name': 'tracker-1.4', 'date': 0},
+            {'name': 'tracker-1.6', 'date': 0},
+            {'name': 'tracker-1.8', 'date': 0},
+            {'name': 'tracker-2.1', 'date': 0},
+            {'name': 'tracker-2.2', 'date': 0},
+            {'name': 'tracker-2.3', 'date': 0},
+            {'name': 'tracker-3.0', 'date': 0},
+            {'name': 'tracker-3.1', 'date': 0},
+            {'name': 'tracker-3.2', 'date': 0},
+            {'name': 'tracker-3.3', 'date': 0},
+            {'name': 'tracker-3.4', 'date': 0},
+            {'name': 'tracker-cmd', 'date': 0},
+            {'name': 'trackerutils-arch-independent', 'date': 0},
+            {'name': 'updated-gtester', 'date': 0},
+            {'name': 'wip/carlosg/automatic-store-shutdown', 'date': 0},
+            {'name': 'wip/carlosg/avahi', 'date': 0},
+            {'name': 'wip/carlosg/ci-playground2', 'date': 0},
+            {'name': 'wip/carlosg/direct-rewrite', 'date': 0},
+            {'name': 'wip/carlosg/domain-ontologies', 'date': 0},
+            {'name': 'wip/carlosg/double-precision', 'date': 0},
+            {'name': 'wip/carlosg/downgrade-meson-version', 'date': 0},
+            {'name': 'wip/carlosg/drop-autotools', 'date': 0},
+            {'name': 'wip/carlosg/fix-bijiben-flatpak', 'date': 0},
+            {'name': 'wip/carlosg/fix-tracker-search', 'date': 0},
+            {'name': 'wip/carlosg/gi-docgen', 'date': 0},
+            {'name': 'wip/carlosg/insert-delete-triggers', 'date': 0},
+            {'name': 'wip/carlosg/issue-40', 'date': 0},
+            {'name': 'wip/carlosg/issue-56', 'date': 0},
+            {'name': 'wip/carlosg/legalese-cardinality', 'date': 0},
+            {'name': 'wip/carlosg/libtracker-miner-cleanups', 'date': 0},
+            {'name': 'wip/carlosg/meson-fixes', 'date': 0},
+            {'name': 'wip/carlosg/meson-system-dirs', 'date': 0},
+            {'name': 'wip/carlosg/ontlogy-tests-no-skip', 'date': 0},
+            {'name': 'wip/carlosg/property-paths', 'date': 0},
+            {'name': 'wip/carlosg/remote-module-extension', 'date': 0},
+            {'name': 'wip/carlosg/resource-deletes', 'date': 0},
+            {'name': 'wip/carlosg/resource-leak-fix', 'date': 0},
+            {'name': 'wip/carlosg/sparql-parser-ng', 'date': 0},
+            {'name': 'wip/carlosg/sparql-shell', 'date': 0},
+            {'name': 'wip/carlosg/trigger-filter-parent-on-monitor-events', 'date': 0},
+            {'name': 'wip/carlosg/unrestricted-predicates', 'date': 0},
+            {'name': 'wip/collect-bug-info', 'date': 0},
+            {'name': 'wip/ernestask/43', 'date': 0},
+            {'name': 'wip/fts5', 'date': 0},
+            {'name': 'wip/garnacho/sparql1.1', 'date': 0},
+            {'name': 'wip/index-mount-points', 'date': 0},
+            {'name': 'wip/jfelder/audio-writeback', 'date': 0},
+            {'name': 'wip/jtojnar/2.1-dist-fix', 'date': 0},
+            {'name': 'wip/lantw/dont-hard-code-usr-bin-python2', 'date': 0},
+            {'name': 'wip/mschraal/meson-log-domain', 'date': 0},
+            {'name': 'wip/mschraal/python3-port', 'date': 0},
+            {'name': 'wip/passive-extraction', 'date': 0},
+            {'name': 'wip/removable-device-completed', 'date': 0},
+            {'name': 'wip/ricotz/type-args', 'date': 0},
+            {'name': 'wip/rishi/non-native', 'date': 0},
+            {'name': 'wip/rishi/tracker-sparql-connection-peer-to-peer', 'date': 0},
+            {'name': 'wip/sam/carlosg/direct-rewrite', 'date': 0},
+            {'name': 'wip/sam/private-store', 'date': 0},
+            {'name': 'wip/sam/test-sqlite', 'date': 0},
+            {'name': 'wip/split/core', 'date': 0},
+            {'name': 'wip/split/miner-fs', 'date': 0},
+            {'name': 'wip/split/rss', 'date': 0},
+            {'name': 'wip/sthursfield/debian10-hacks', 'date': 0},
+            {'name': 'wip/tintou/fix-doc', 'date': 0}
+        ],
+        "https://gitlab.gnome.org/GNOME/gnome-boxes.git":
+        [{'name': 'account-for-interference-on-reboot-count', 'date': 0},
+            {'name': 'alatiera/sourceview', 'date': 0},
+            {'name': 'bundle-mks', 'date': 0},
+            {'name': 'check-kvm-user', 'date': 0},
+            {'name': 'create-qcow2-with-compat1.1', 'date': 0},
+            {'name': 'flatpak-net-bridge', 'date': 0},
+            {'name': 'flatpak-use-vala-lang-server-sdk', 'date': 0},
+            {'name': 'gnome-3-10', 'date': 0},
+            {'name': 'gnome-3-12', 'date': 0},
+            {'name': 'gnome-3-14', 'date': 0},
+            {'name': 'gnome-3-16', 'date': 0},
+            {'name': 'gnome-3-18', 'date': 0},
+            {'name': 'gnome-3-20', 'date': 0},
+            {'name': 'gnome-3-22', 'date': 0},
+            {'name': 'gnome-3-24', 'date': 0},
+            {'name': 'gnome-3-26', 'date': 0},
+            {'name': 'gnome-3-28', 'date': 0},
+            {'name': 'gnome-3-30', 'date': 0},
+            {'name': 'gnome-3-32', 'date': 0},
+            {'name': 'gnome-3-34', 'date': 0},
+            {'name': 'gnome-3-36', 'date': 0},
+            {'name': 'gnome-3-38', 'date': 0},
+            {'name': 'gnome-3-4', 'date': 0},
+            {'name': 'gnome-3-6', 'date': 0},
+            {'name': 'gnome-3-8', 'date': 0},
+            {'name': 'gnome-40', 'date': 0},
+            {'name': 'gnome-40-fix-run-in-bg', 'date': 0},
+            {'name': 'gnome-41', 'date': 0},
+            {'name': 'gnome-41-fix-clones-regression', 'date': 0},
+            {'name': 'gnome-42', 'date': 0},
+            {'name': 'gnome-43', 'date': 0},
+            {'name': 'gnome-44', 'date': 0},
+            {'name': 'libvirt-socket-path-long-2022', 'date': 0},
+            {'name': 'main', 'date': 0},
+            {'name': 'osdb-prefer-x86_64_resources-by-default', 'date': 0},
+            {'name': 'restore-support-to-download', 'date': 0},
+            {'name': 'update-po-files', 'date': 0},
+            {'name': 'wip/arm', 'date': 0},
+            {'name': 'wip/codespell-ci', 'date': 0},
+            {'name': 'wip/disable-secure-boot', 'date': 0},
+            {'name': 'wip/dont-continue-installations-on-restart', 'date': 0},
+            {'name': 'wip/empty-state-update-graphic', 'date': 0},
+            {'name': 'wip/feborges/flatpak-net-bridge', 'date': 0},
+            {'name': 'wip/feborges/no-filesystem-access', 'date': 0},
+            {'name': 'wip/new-properties-dialog', 'date': 0},
+            {'name': 'wip/sam/tracker3', 'date': 0},
+            {'name': 'wip/support-windows-11', 'date': 0},
+            {'name': 'workaround-audio-regression', 'date': 0}
+        ]
+    }
 
 def get_gnome_calculator_tags():
     """ Returns a plausible list of tags for several tests """

--- a/updatesnap/tests/gnome-boxes-test1.yaml
+++ b/updatesnap/tests/gnome-boxes-test1.yaml
@@ -1,0 +1,375 @@
+name: gnome-boxes
+adopt-info: gnome-boxes
+grade: stable # must be 'stable' to release into candidate/stable channels
+confinement: strict
+base: core20
+
+layout:
+  /usr/share/gnome-boxes:
+    bind: $SNAP/usr/share/gnome-boxes
+  /usr/share/osinfo:
+    bind: $SNAP/usr/share/osinfo
+  /usr/share/misc/usb.ids:
+    symlink: $SNAP/usr/share/misc/usb.ids
+  /usr/share/misc/pci.ids:
+    symlink: $SNAP/usr/share/misc/pci.ids
+  /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libvirt:
+    bind: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libvirt
+  /usr/share/libvirt:
+    bind: $SNAP/usr/share/libvirt
+  /usr/lib/libvirt:
+    bind: $SNAP/usr/lib/libvirt
+  /usr/share/seabios:
+    bind: $SNAP/usr/share/seabios
+  /usr/lib/ipxe:
+    bind: $SNAP/usr/lib/ipxe
+  /usr/bin/qemu-system-x86_64:
+    bind-file: $SNAP/usr/bin/qemu-system-x86_64
+  /usr/sbin/dnsmasq:
+    bind-file: $SNAP/usr/sbin/dnsmasq
+  /usr/share/qemu:
+    bind: $SNAP/usr/share/qemu
+  /etc/libvirt:
+    bind: $SNAP/etc/libvirt
+  /usr/libexec/libvirt_iohelper:
+    bind-file: $SNAP/usr/libexec/libvirt_iohelper
+
+slots:
+  # for GtkApplication registration
+  gnome-boxes:
+    interface: dbus
+    bus: session
+    name: org.gnome.Boxes
+
+apps:
+  gnome-boxes:
+    command: usr/bin/gnome-boxes
+    command-chain: [ bin/launcher ]
+    extensions: [gnome-3-38]
+    plugs:
+      - audio-record
+      - audio-playback
+      - camera
+      - hardware-observe
+      - home
+      - kvm
+      - login-session-observe
+      - mount-observe
+      - network
+      - network-bind
+      - network-status
+      - process-control
+      - raw-usb
+      - system-observe
+      - time-control
+      - udisks2
+      - upower-observe
+    desktop: usr/share/applications/org.gnome.Boxes.desktop
+    common-id: org.gnome.Boxes.desktop
+    environment:
+      LD_LIBRARY_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gnome-boxes
+      GI_TYPELIB_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gnome-boxes/girepository-1.0:$GI_TYPELIB_PATH
+      GTK_USE_PORTAL: '0'
+
+parts:
+  libvirt:
+    source: https://gitlab.com/libvirt/libvirt.git
+    source-depth: 1
+    source-branch: v6.0.0
+    plugin: autotools
+    build-packages:
+      - libxml2-dev
+      - libncurses5-dev
+      - libreadline-dev
+      - zlib1g-dev
+      - libgcrypt20-dev
+      - libgnutls28-dev
+      - libsasl2-dev
+      - libxen-dev
+      - libparted-dev
+      - libdevmapper-dev
+      - uuid-dev
+      - libudev-dev
+      - libpciaccess-dev
+      - libcurl4-gnutls-dev
+      - libpolkit-gobject-1-dev
+      - libcap-ng-dev
+      - libnl-3-dev
+      - libnl-route-3-dev
+      - libyajl-dev
+      - libpcap0.8-dev
+      - libnuma-dev
+      - libsanlock-dev
+      - libaudit-dev
+      - libselinux1-dev
+      - libapparmor-dev
+      - libdbus-1-dev
+      - systemtap-sdt-dev
+      - libzfslinux-dev
+      - librbd-dev
+      - librados-dev
+      - libglusterfs-dev
+      - libwireshark-dev
+      - libwiretap-dev
+      - libfuse-dev
+      - qemu-utils
+      - python3-docutils
+      - qemu-system-common
+      - xsltproc
+    stage-packages:
+      - libacl1
+      - libapparmor1
+      - libaudit1
+      - libblkid1
+      - libcap-ng0
+      - libcurl3-gnutls
+      - libdbus-1-3
+      - libdevmapper1.02.1
+      - libfuse2
+      - libgcc-s1
+      - libgfapi0
+      - libgfrpc0
+      - libgfxdr0
+      - libglib2.0-0
+      - libglusterfs0
+      - libgnutls30
+      - libnl-3-200
+      - libnuma1
+      - libparted2
+      - libpcap0.8
+      - librados2
+      - librbd1
+      - libsanlock-client1
+      - libsasl2-2
+      - libselinux1
+      - libtirpc3
+      - libudev1
+      - libxencall1
+      - libxenmisc4.11
+      - libxendevicemodel1
+      - libxenevtchn1
+      - libxenforeignmemory1
+      - libxengnttab1
+      - libxenstore3.0
+      - libxentoolcore1
+      - libxentoollog1
+      - libxml2
+      - libyajl2
+    build-environment:
+      - CFLAGS: "-Wno-error"
+    override-build: |
+      git apply $SNAPCRAFT_PROJECT_DIR/patches/libvirt-qemu.patch
+      mkdir build && cd build
+      ../autogen.sh --prefix=/usr --sysconfdir=/etc --localstatedir=/var --with-qemu
+      make
+      DESTDIR=$SNAPCRAFT_PART_INSTALL make install
+    prime:
+      - -usr/include
+      - -usr/lib/pkgconfig
+
+  libvirt-glib:
+    source: https://github.com/libvirt/libvirt-glib.git
+    after: [ libvirt ]
+    source-depth: 1
+    plugin: meson
+    meson-parameters:
+      - --prefix=/usr
+      - --buildtype=release
+    build-packages:
+      - libvirt-dev
+    prime:
+      - usr/lib/*/*.so.*
+
+  libhandy:
+    source: https://gitlab.gnome.org/GNOME/libhandy.git
+    source-tag: '1.5.91'
+    source-depth: 1
+    plugin: meson
+    meson-parameters:
+      - --prefix=/usr
+      - --buildtype=release
+      - -Dgtk_doc=false
+      - -Dtests=false
+      - -Dexamples=false
+      - -Dglade_catalog=disabled
+    prime:
+      - usr/lib/*/*.so.*
+
+  tracker:
+    source: https://gitlab.gnome.org/GNOME/tracker.git
+    source-branch: 'tracker-3.3'
+    source-depth: 1
+    plugin: meson
+    meson-version: 0.61.3
+    meson-parameters:
+      - --prefix=/usr
+      - --buildtype=release
+      - -Ddocs=false
+      - -Dman=false
+      - -Dbash_completion=false
+      - -Dsystemd_user_services=false
+      - -Dtest_utils=false
+      - -Dintrospection=disabled
+    build-packages:
+      - asciidoc
+      - libspice-client-gtk-3.0-dev
+    override-pull: |
+      set -eux
+      snapcraftctl pull
+      # disabling man and docs seems to be ignored by meson
+      sed -i "s#subdir('docs')##g" meson.build
+    prime:
+      - usr/lib/*/*.so.*
+
+  gnome-boxes:
+    after: [ libvirt-glib, libhandy, tracker ]
+    source: https://gitlab.gnome.org/GNOME/gnome-boxes.git
+    #source-tag: '42.rc'
+    source-branch: 'gnome-42'
+    parse-info: [usr/share/metainfo/org.gnome.Boxes.appdata.xml]
+    plugin: meson
+    meson-parameters:
+      - --prefix=/usr
+      - -Ddistributor_name=Ubuntu
+    meson-version: 0.60.1
+    organize:
+      snap/gnome-boxes/current/usr: usr
+    build-packages:
+      - libarchive-dev
+      - libgtk-vnc-2.0-dev
+      - libosinfo-1.0-dev
+      - libusb-1.0-0-dev
+      - cmake
+    override-pull: |
+      snapcraftctl pull
+      snapcraftctl set-version $(git describe --tags --abbrev=10)
+      sed -i.bak -e "s|symlink_media: true|symlink_media: false|g" $SNAPCRAFT_PART_SRC/help/meson.build
+      # Ensure we save VMs in $SNAP_USER_COMMON
+      git apply $SNAPCRAFT_PROJECT_DIR/patches/gnome-boxes-snap-user-common.patch
+      # Update recommended downloads
+      git apply $SNAPCRAFT_PROJECT_DIR/patches/gnome-boxes-recommended-downloads.patch
+    build-environment:
+      - C_INCLUDE_PATH: $C_INCLUDE_PATH:$SNAPCRAFT_STAGE/usr/include/libvirt-gconfig-1.0:$SNAPCRAFT_STAGE/usr/include/libvirt-glib-1.0:$SNAPCRAFT_STAGE/usr/include/libvirt-gobject-1.0
+      - LD_LIBRARY_PATH: $SNAPCRAFT_STAGE/usr/lib/$SNAPCRAFT_ARCH_TRIPLET:$LD_LIBRARY_PATH
+      - PKG_CONFIG_PATH: $SNAPCRAFT_STAGE/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pkgconfig:$PKG_CONFIG_PATH
+
+  libraries:
+    after: [ gnome-boxes ]
+    plugin: nil
+    stage-packages:
+      - libasn1-8-heimdal
+      - libcacard0
+      - libcurl3-gnutls
+      - libgssapi3-heimdal
+      - libgtk-vnc-2.0-0
+      - libgvnc-1.0-0
+      - libhcrypto4-heimdal
+      - libheimbase1-heimdal
+      - libheimntlm0-heimdal
+      - libhx509-5-heimdal
+      - libkrb5-26-heimdal
+      - libldap-2.4-2
+      - libnghttp2-14
+      - libnspr4
+      - libnss3
+      - libnuma1
+      - libopus0
+      - libosinfo-1.0-0
+      - libphodav-2.0-0
+      - libroken18-heimdal
+      - librtmp1
+      - libsasl2-2
+      - libspice-client-glib-2.0-8
+      - libspice-client-gtk-3.0-5
+      - libssh-4
+      - libusb-1.0-0
+      - libusbredirhost1
+      - libusbredirparser1
+      - libva-x11-2
+      - libwind0-heimdal
+      - libyajl2
+      - libosinfo-bin
+      - pci.ids
+      - usb.ids
+
+    stage:
+      - -usr/share/osinfo
+
+    prime:
+      - usr/lib/*/libasn*.so.*
+      - usr/lib/*/libcaca*.so.*
+      - usr/lib/*/libcurl*.so.*
+      - usr/lib/*/libgss**.so.*
+      - usr/lib/*/libgtk-vnc*.so.*
+      - usr/lib/*/libgvnc*.so.*
+      - usr/lib/*/libhcrypt*.so.*
+      - usr/lib/*/libhei*.so.*
+      - usr/lib/*/libhx*.so.*
+      - usr/lib/*/libkrb*.so.*
+      - usr/lib/*/liblber*.so.*
+      - usr/lib/*/libldap*.so.*
+      - usr/lib/*/libng*.so.*
+      - usr/lib/*/libns*.so*
+      - usr/lib/*/libnuma*.so.*
+      - usr/lib/*/libopus*.so.*
+      - usr/lib/*/libosinfo*.so.*
+      - usr/lib/*/libphodav*.so.*
+      - usr/lib/*/libplc*.so*
+      - usr/lib/*/libpld*.so*
+      - usr/lib/*/libroken*.so.*
+      - usr/lib/*/librtmp*.so.*
+      - usr/lib/*/libsasl*.so.*
+      - usr/lib/*/libspice*.so.*
+      - usr/lib/*/libssh*.so.*
+      - usr/lib/*/libusb*.so.*
+      - lib/*/libusb*.so.*
+      - usr/lib/*/libva*.so.*
+      - usr/lib/*/libwind*.so.*
+      - usr/lib/*/libyaj*.so.*
+      - usr/bin/osinfo*
+      - usr/share/misc/pci.ids
+      - usr/share/misc/usb.ids
+      - var/lib/usbutils/usb.ids
+      
+  osinfo-db:
+    plugin: make
+    after: [ libraries ]
+    source: https://salsa.debian.org/libvirt-team/osinfo-db.git
+    build-packages:
+      - gettext
+      - osinfo-db-tools
+      - wget
+    override-build: |
+      snapcraftctl build
+      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/share/osinfo
+      tar xf osinfo-db-*.tar.xz --strip-components=1 -C $SNAPCRAFT_PART_INSTALL/usr/share/osinfo
+      cp $SNAPCRAFT_PROJECT_DIR/ubuntu-daily.xml $SNAPCRAFT_PART_INSTALL/usr/share/osinfo/os/ubuntu.com/
+      # fix broken focal revision
+      FOCAL="$(wget -O- -q http://changelogs.ubuntu.com/meta-release-lts | grep "Version: 20.04" | cut -d' ' -f2)"
+      sed -i "s/20.04.3/$FOCAL/" $SNAPCRAFT_PART_INSTALL/usr/share/osinfo/os/ubuntu.com/ubuntu-20.04.xml
+
+  qemu:
+    plugin: nil
+    after: [ osinfo-db ]
+    stage-snaps: [ qemu-virgil/latest/edge ]
+    stage-packages:
+      - dnsmasq-base
+
+  launcher:
+    plugin: dump
+    after: [ qemu ]
+    source: scripts
+    organize:
+      launcher.sh: bin/launcher
+
+  # Find files provided by the base and platform snap and ensure they aren't
+  # duplicated in this snap
+  #cleanup:
+  #  after: [ libraries ]
+  #  plugin: nil
+  #  build-snaps: [core20, gtk-common-themes, gnome-3-38-2004]
+  #  override-prime: |
+  #    set -eux
+  #    for snap in "core20" "gtk-common-themes" "gnome-3-38-2004"; do
+  #      cd "/snap/$snap/current" && find . -type f,l -name *.so.* -exec rm -f "$SNAPCRAFT_PRIME/{}" \;
+  #    done

--- a/updatesnap/updatesnapyaml.py
+++ b/updatesnap/updatesnapyaml.py
@@ -102,7 +102,7 @@ def main():
         if not version_data:
             continue
         print(f"Updating '{part['name']}' from version '{part['version'][0]}'"
-            " to version '{part['updates'][0]['name']}'", file=sys.stderr)
+              f" to version '{part['updates'][0]['name']}'", file=sys.stderr)
         version_data['data'] = f"source-tag: '{part['updates'][0]['name']}'"
         has_update = True
 


### PR DESCRIPTION
If a part in a snapcraft.yaml file uses branches instead of tags, the code fails. This patch fixes it.