### PR TITLE
Add tags to allow source-branch and no source

### DIFF
--- a/updatesnap/README.md
+++ b/updatesnap/README.md
@@ -144,6 +144,13 @@ The available extra tokens are:
   greater than 90 will be ignored. Useful for projects that use these revision numbers
   as "prelude" to a new minor version.
 * ignore: don't try to check this entry. Useful for "archived" projects.
+* allow-neither-tag-nor-branch: allows this part to have neither *source-tag* nor
+  *source-branch* elements, thus using the default (usually *main*) branch. Without
+  this element, a file with a part that has neither *source-tag* nor *source-branch*
+  will be considered invalid.
+* allow-branch: allows to use *source-branch* in the part instead of *source-tag*.
+  A file with a part that has neither *source-tag* nor this element will be considered
+  invalid.
 
 ## TODO
 

--- a/updatesnap/tests/test_branch_no_permission.yaml
+++ b/updatesnap/tests/test_branch_no_permission.yaml
@@ -1,0 +1,44 @@
+name: gnome-boxes
+adopt-info: gnome-boxes
+grade: stable # must be 'stable' to release into candidate/stable channels
+confinement: strict
+base: core20
+
+apps:
+  gnome-boxes:
+    command: usr/bin/gnome-boxes
+    command-chain: [ bin/launcher ]
+    extensions: [gnome-3-38]
+    plugs:
+      - audio-record
+      - audio-playback
+      - camera
+      - hardware-observe
+      - home
+      - kvm
+      - login-session-observe
+      - mount-observe
+      - network
+      - network-bind
+      - network-status
+      - process-control
+      - raw-usb
+      - system-observe
+      - time-control
+      - udisks2
+      - upower-observe
+    desktop: usr/share/applications/org.gnome.Boxes.desktop
+    common-id: org.gnome.Boxes.desktop
+    environment:
+      LD_LIBRARY_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gnome-boxes
+      GI_TYPELIB_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gnome-boxes/girepository-1.0:$GI_TYPELIB_PATH
+      GTK_USE_PORTAL: '0'
+
+parts:
+  libvirt:
+    source: https://gitlab.com/libvirt/libvirt.git
+    source-depth: 1
+    source-branch: v6.0.0
+    plugin: autotools
+    build-packages:
+      - libxml2-dev

--- a/updatesnap/tests/test_branch_with_permission.yaml
+++ b/updatesnap/tests/test_branch_with_permission.yaml
@@ -1,0 +1,47 @@
+name: gnome-boxes
+adopt-info: gnome-boxes
+grade: stable # must be 'stable' to release into candidate/stable channels
+confinement: strict
+base: core20
+
+apps:
+  gnome-boxes:
+    command: usr/bin/gnome-boxes
+    command-chain: [ bin/launcher ]
+    extensions: [gnome-3-38]
+    plugs:
+      - audio-record
+      - audio-playback
+      - camera
+      - hardware-observe
+      - home
+      - kvm
+      - login-session-observe
+      - mount-observe
+      - network
+      - network-bind
+      - network-status
+      - process-control
+      - raw-usb
+      - system-observe
+      - time-control
+      - udisks2
+      - upower-observe
+    desktop: usr/share/applications/org.gnome.Boxes.desktop
+    common-id: org.gnome.Boxes.desktop
+    environment:
+      LD_LIBRARY_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gnome-boxes
+      GI_TYPELIB_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gnome-boxes/girepository-1.0:$GI_TYPELIB_PATH
+      GTK_USE_PORTAL: '0'
+
+parts:
+  libvirt:
+    source: https://gitlab.com/libvirt/libvirt.git
+    source-depth: 1
+    source-branch: v6.0.0
+    plugin: autotools
+    build-packages:
+      - libxml2-dev
+# ext:updatesnap
+#   version-format:
+#     allow-branch: true

--- a/updatesnap/tests/test_no_tag_no_branch_no_permission.yaml
+++ b/updatesnap/tests/test_no_tag_no_branch_no_permission.yaml
@@ -1,0 +1,49 @@
+name: gnome-boxes
+adopt-info: gnome-boxes
+grade: stable # must be 'stable' to release into candidate/stable channels
+confinement: strict
+base: core20
+
+apps:
+  gnome-boxes:
+    command: usr/bin/gnome-boxes
+    command-chain: [ bin/launcher ]
+    extensions: [gnome-3-38]
+    plugs:
+      - audio-record
+      - audio-playback
+      - camera
+      - hardware-observe
+      - home
+      - kvm
+      - login-session-observe
+      - mount-observe
+      - network
+      - network-bind
+      - network-status
+      - process-control
+      - raw-usb
+      - system-observe
+      - time-control
+      - udisks2
+      - upower-observe
+    desktop: usr/share/applications/org.gnome.Boxes.desktop
+    common-id: org.gnome.Boxes.desktop
+    environment:
+      LD_LIBRARY_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gnome-boxes
+      GI_TYPELIB_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gnome-boxes/girepository-1.0:$GI_TYPELIB_PATH
+      GTK_USE_PORTAL: '0'
+
+parts:
+  libvirt-glib:
+    source: https://github.com/libvirt/libvirt-glib.git
+    after: [ libvirt ]
+    source-depth: 1
+    plugin: meson
+    meson-parameters:
+      - --prefix=/usr
+      - --buildtype=release
+    build-packages:
+      - libvirt-dev
+    prime:
+      - usr/lib/*/*.so.*

--- a/updatesnap/tests/test_no_tag_no_branch_with_permission.yaml
+++ b/updatesnap/tests/test_no_tag_no_branch_with_permission.yaml
@@ -1,0 +1,52 @@
+name: gnome-boxes
+adopt-info: gnome-boxes
+grade: stable # must be 'stable' to release into candidate/stable channels
+confinement: strict
+base: core20
+
+apps:
+  gnome-boxes:
+    command: usr/bin/gnome-boxes
+    command-chain: [ bin/launcher ]
+    extensions: [gnome-3-38]
+    plugs:
+      - audio-record
+      - audio-playback
+      - camera
+      - hardware-observe
+      - home
+      - kvm
+      - login-session-observe
+      - mount-observe
+      - network
+      - network-bind
+      - network-status
+      - process-control
+      - raw-usb
+      - system-observe
+      - time-control
+      - udisks2
+      - upower-observe
+    desktop: usr/share/applications/org.gnome.Boxes.desktop
+    common-id: org.gnome.Boxes.desktop
+    environment:
+      LD_LIBRARY_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gnome-boxes
+      GI_TYPELIB_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gnome-boxes/girepository-1.0:$GI_TYPELIB_PATH
+      GTK_USE_PORTAL: '0'
+
+parts:
+  libvirt-glib:
+    source: https://github.com/libvirt/libvirt-glib.git
+    after: [ libvirt ]
+    source-depth: 1
+    plugin: meson
+    meson-parameters:
+      - --prefix=/usr
+      - --buildtype=release
+    build-packages:
+      - libvirt-dev
+    prime:
+      - usr/lib/*/*.so.*
+# ext:updatesnap
+#   version-format:
+#     allow-neither-tag-nor-branch: true

--- a/updatesnap/unittests.py
+++ b/updatesnap/unittests.py
@@ -65,7 +65,8 @@ class TestYAMLfiles(unittest.TestCase):
         """ tests if it detects the right list of available updates """
         snap, _ = self._load_test_file("gnome-calculator-test1.yaml",
                                        get_gnome_calculator_tags())
-        data = snap.process_parts()
+        data, tag_error = snap.process_parts()
+        assert not tag_error
         assert self._ensure_tags(data[0]["updates"], ["44.0", "43.0.1", "43.0"])
         assert not self._ensure_tags(data[0]["updates"], ["44.0", "43.0.1", "43.0", "42.2"])
 
@@ -73,7 +74,8 @@ class TestYAMLfiles(unittest.TestCase):
         """ tests if the updated snapcraft.yaml file is correct """
         snap, datafile = self._load_test_file("gnome-calculator-test1.yaml",
                                               get_gnome_calculator_tags())
-        data = snap.process_parts()
+        data, tag_error = snap.process_parts()
+        assert not tag_error
         manager_yaml = ManageYAML(datafile)
         has_update = False
         for part in data:
@@ -95,7 +97,8 @@ class TestYAMLfiles(unittest.TestCase):
         """ Ensure that the updated file identical to the expected one """
         snap, datafile = self._load_test_file("gnome-calculator-test1.yaml",
                                               get_gnome_calculator_tags())
-        data = snap.process_parts()
+        data, tag_error = snap.process_parts()
+        assert not tag_error
         assert len(data) == 2
         assert "name" in data[0]
         assert "version" in data[0]
@@ -172,7 +175,8 @@ class TestYAMLfiles(unittest.TestCase):
         snap, _ = self._load_test_file("gnome-boxes-test1.yaml",
                                        None,
                                        get_gnome_boxes_branches())
-        snap.process_parts()
+        _, tag_error = snap.process_parts()
+        assert tag_error
 
     def test_gitlab_tags_download(self):
         """ Check that tag download from gitlab works as expected """
@@ -190,6 +194,42 @@ class TestYAMLfiles(unittest.TestCase):
                     found = True
                     break
             assert found
+
+    def test_branch_no_permission(self):
+        """ Checks that a file using source-branch without permission triggers
+            an error """
+        snap, _ = self._load_test_file("test_branch_no_permission.yaml",
+                                       None,
+                                       get_gnome_boxes_branches())
+        _, tag_error = snap.process_parts()
+        assert tag_error
+
+    def test_branch_with_permission(self):
+        """ Checks that a file using source-branch with permission doesn't
+            trigger an error """
+        snap, _ = self._load_test_file("test_branch_with_permission.yaml",
+                                       None,
+                                       get_gnome_boxes_branches())
+        _, tag_error = snap.process_parts()
+        assert not tag_error
+
+    def test_no_tag_no_branch_no_permission(self):
+        """ Checks that a file with neither source-branch nor source-tag without
+            permission triggers an error """
+        snap, _ = self._load_test_file("test_no_tag_no_branch_no_permission.yaml",
+                                       None,
+                                       get_gnome_boxes_branches())
+        _, tag_error = snap.process_parts()
+        assert tag_error
+
+    def test_no_tag_no_branch_with_permission(self):
+        """ Checks that a file with neither source-branch nor source-tag with
+            permission doesn't trigger an error """
+        snap, _ = self._load_test_file("test_no_tag_no_branch_with_permission.yaml",
+                                       None,
+                                       get_gnome_boxes_branches())
+        _, tag_error = snap.process_parts()
+        assert not tag_error
 
 
 class GitPose:

--- a/updatesnap/updatesnap.py
+++ b/updatesnap/updatesnap.py
@@ -18,7 +18,7 @@ def apply_local_secrets(snap, arguments):
         snap.set_secret("github", "token", arguments.github_token)
 
 
-def process_folder(folder_path, arguments):
+def process_folder(folder_path, arguments) -> tuple[list, bool]:
     """ Processes a folder, searching for the snapcraft.yaml files """
 
     snap = Snapcraft(arguments.s)
@@ -32,7 +32,7 @@ def process_folder(folder_path, arguments):
     return snap.process_parts()
 
 
-def process_data(data, arguments):
+def process_data(data, arguments) -> tuple[list, bool]:
     """ Processed a YAML data passed in the data argument """
 
     snap = Snapcraft(arguments.s)
@@ -100,18 +100,21 @@ def main():
             full_path = os.path.join(argument_list.folder, folder)
             if not os.path.isdir(full_path):
                 continue
-            retval += process_folder(full_path, argument_list)
+            data, _ = process_folder(full_path, argument_list)
+            retval += data
     else:
         if ((not argument_list.folder.startswith("http://")) and
                 (not argument_list.folder.startswith("https://"))):
-            retval = process_folder(argument_list.folder, argument_list)
+            data, _ = process_folder(argument_list.folder, argument_list)
+            retval = data
         else:
             response = requests.get(argument_list.folder, timeout=30)
             if not response:
                 print(f"Failed to get the file {argument_list.folder}: {response.status_code}",
                       file=sys.stderr)
                 sys.exit(-1)
-            retval = process_data(response.content.decode('utf-8'), argument_list)
+            data, _ = process_data(response.content.decode('utf-8'), argument_list)
+            retval = data
     print_summary(retval)
 
 

--- a/updatesnap/updatesnapyaml.py
+++ b/updatesnap/updatesnapyaml.py
@@ -85,7 +85,10 @@ def main():
         snap.set_secret('github', 'user', arguments.github_user)
     if arguments.github_token:
         snap.set_secret('github', 'token', arguments.github_token)
-    parts = snap.process_parts()
+    parts, tag_error = snap.process_parts()
+
+    if tag_error:
+        sys.exit(1)
 
     if len(parts) == 0:
         print("The snapcraft.yaml file has no parts.", file=sys.stderr)


### PR DESCRIPTION
This PR adds two new tags for the "version-format" metadata:

  * allow-branch: this tag allows to use source-branch instead of using source-tag in a part. Without it, using source-branch is invalid and an error will be triggered.

  * allow-neither-tag-nor- branch: this tag allows to don't have to put neither source-tag nor source-branch in a part, thus the code in the default branch will be used. Without it, a part lacking source-tag is invalid and an error will be triggered.