### PR TITLE
Mandates "source-depth" entry

### DIFF
--- a/updatesnap/SnapModule/snapmodule.py
+++ b/updatesnap/SnapModule/snapmodule.py
@@ -409,7 +409,7 @@ class Snapcraft(ProcessVersion):
         super().__init__(silent)
         self._secrets = {}
         self._config = None
-        self._branch_tag_error = False
+        self._tag_error = False
         if github_pose:
             self._github = github_pose
         else:
@@ -534,11 +534,11 @@ class Snapcraft(ProcessVersion):
         updates the version to the latest one. """
         if self._config is None:
             return []
-        self._branch_tag_error = False
+        self._tag_error = False
         parts = []
         for part in self._config['parts']:
             parts.append(self.process_part(part))
-        return parts, self._branch_tag_error
+        return parts, self._tag_error
 
     def process_part(self, part: str) -> Optional[dict]:
         # pylint: disable=too-many-return-statements,too-many-branches,too-many-statements
@@ -616,6 +616,13 @@ class Snapcraft(ProcessVersion):
             print("", file=sys.stderr)
             return part_data
 
+        if "source-depth" not in data:
+            self._tag_error = True
+            self._print_message(part, f"{self._colors.critical}No 'source-depth' entry"
+                                f"{self._colors.reset}", source=source)
+            print("", file=sys.stderr)
+            return part_data
+
         if 'savannah' in source:
             url = urllib.parse.urlparse(source)
             if 'savannah' in url.netloc:
@@ -637,7 +644,7 @@ class Snapcraft(ProcessVersion):
             else:
                 self._print_message(part, f"{self._colors.critical}{message}{self._colors.reset}",
                                     source=source, override_silent=True)
-                self._branch_tag_error = True
+                self._tag_error = True
             if tags is not None:
                 self._print_last_tags(part, tags)
 
@@ -663,7 +670,7 @@ class Snapcraft(ProcessVersion):
                 self._print_message(part, f"{self._colors.warning}{message}{self._colors.reset}",
                                     override_silent=True)
             else:
-                self._branch_tag_error = True
+                self._tag_error = True
                 self._print_message(part, f"{self._colors.critical}{message}{self._colors.reset}",
                                     override_silent=True)
         if not self._silent:

--- a/updatesnap/tests/gnome-calculator-test1-updated.yaml
+++ b/updatesnap/tests/gnome-calculator-test1-updated.yaml
@@ -46,6 +46,7 @@ parts:
   gnome-calculator:
     source: https://gitlab.gnome.org/GNOME/gnome-calculator.git
     source-tag: '44.0'
+    source-depth: 1
 # ext:updatesnap
 #   version-format:
 #     no-9x-revisions: true

--- a/updatesnap/tests/gnome-calculator-test1.yaml
+++ b/updatesnap/tests/gnome-calculator-test1.yaml
@@ -46,6 +46,7 @@ parts:
   gnome-calculator:
     source: https://gitlab.gnome.org/GNOME/gnome-calculator.git
     source-tag: '42.2'
+    source-depth: 1
 # ext:updatesnap
 #   version-format:
 #     no-9x-revisions: true

--- a/updatesnap/tests/test_no_depth.yaml
+++ b/updatesnap/tests/test_no_depth.yaml
@@ -1,0 +1,46 @@
+name: gnome-boxes
+adopt-info: gnome-boxes
+grade: stable # must be 'stable' to release into candidate/stable channels
+confinement: strict
+base: core20
+
+apps:
+  gnome-boxes:
+    command: usr/bin/gnome-boxes
+    command-chain: [ bin/launcher ]
+    extensions: [gnome-3-38]
+    plugs:
+      - audio-record
+      - audio-playback
+      - camera
+      - hardware-observe
+      - home
+      - kvm
+      - login-session-observe
+      - mount-observe
+      - network
+      - network-bind
+      - network-status
+      - process-control
+      - raw-usb
+      - system-observe
+      - time-control
+      - udisks2
+      - upower-observe
+    desktop: usr/share/applications/org.gnome.Boxes.desktop
+    common-id: org.gnome.Boxes.desktop
+    environment:
+      LD_LIBRARY_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gnome-boxes
+      GI_TYPELIB_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gnome-boxes/girepository-1.0:$GI_TYPELIB_PATH
+      GTK_USE_PORTAL: '0'
+
+parts:
+  libvirt:
+    source: https://gitlab.com/libvirt/libvirt.git
+    source-branch: v6.0.0
+    plugin: autotools
+    build-packages:
+      - libxml2-dev
+# ext:updatesnap
+#   version-format:
+#     allow-branch: true

--- a/updatesnap/unittests.py
+++ b/updatesnap/unittests.py
@@ -231,6 +231,14 @@ class TestYAMLfiles(unittest.TestCase):
         _, tag_error = snap.process_parts()
         assert not tag_error
 
+    def test_no_depth(self):
+        """ Checks that a file without 'source-depth' triggers an error """
+        snap, _ = self._load_test_file("test_no_depth.yaml",
+                                       None,
+                                       get_gnome_boxes_branches())
+        _, tag_error = snap.process_parts()
+        assert tag_error
+
 
 class GitPose:
     """ Helper class. It emulates a GitClass class, to allow to test


### PR DESCRIPTION
This entry downloads only the last commit of a GIT repository, thus reducing the bandwidth and the disk size required for building a snap.

Doing it mandatory is, thus, a good idea.