### PR TITLE
Don't crash if part has neither tag nor branch

### DIFF
--- a/updatesnap/SnapModule/snapmodule.py
+++ b/updatesnap/SnapModule/snapmodule.py
@@ -823,6 +823,8 @@ class ManageYAML:
         for entry in self._tree:
             if entry['data'] != 'parts:':
                 continue
+            if ('child' not in entry) or (entry['child'] is None):
+                continue
             for entry2 in entry['child']:
                 if entry2['data'] != f'{part_name}:':
                     continue


### PR DESCRIPTION
If a part has neither a source-tag nor a source-branch tag, the check must continue, just returning "no updates" for that element instead of crashing with a "nonetype" is not iterable.