### PR TITLE
Fix parsing failure

### DIFF
--- a/updatesnap/SnapModule/snapmodule.py
+++ b/updatesnap/SnapModule/snapmodule.py
@@ -821,10 +821,12 @@ class ManageYAML:
         data = []
         while len(contents) != 0:
             if len(contents[0].lstrip()) == 0 or contents[0][0] == '#':
-                data.append({'separator': '',
-                             'data': contents[0].lstrip(),
-                             'child': None,
-                             'level': clevel})
+                if data[-1]['child'] is None:
+                    data[-1]['child'] = []
+                data[-1]['child'].append({'separator': '',
+                                          'data': contents[0].lstrip(),
+                                          'child': None,
+                                          'level': clevel + 1})
                 contents = contents[1:]
                 continue
             if not contents[0].startswith(separator * level):
@@ -844,7 +846,10 @@ class ManageYAML:
                 level += 1
             contents, inner_data = self._split_yaml(contents, level, clevel+1, separator)
             level = old_level
-            data[-1]['child'] = inner_data
+            if data[-1]['child'] is None:
+                data[-1]['child'] = inner_data
+            else:
+                data[-1]['child'] += inner_data
         return [], data
 
     def get_part_data(self, part_name: str) -> Optional[dict]:
@@ -864,7 +869,7 @@ class ManageYAML:
                 return entry2['child']
         return None
 
-    def get_part_element(self, part_name: int, element: str) -> Optional[dict]:
+    def get_part_element(self, part_name: str, element: str) -> Optional[dict]:
         """ Returns an specific entry for an specific part in the YAML file.
             For example, it can returns the 'source-tag' entry of the part
             'glib' from a YAML file with several parts. """

--- a/updatesnap/tests/aligned_comment.yaml
+++ b/updatesnap/tests/aligned_comment.yaml
@@ -1,0 +1,102 @@
+name: gnome-system-monitor
+adopt-info: gnome-system-monitor
+summary: System Monitor
+description: |
+  GNOME System Monitor is a GNOME process viewer and system monitor with
+  an attractive, easy-to-use interface, It has features, such as a tree
+  view for process dependencies, icons for processes, the ability to hide
+  processes that you don't want to see, graphical time histories of
+  CPU/memory/swap usage, the ability to kill/renice processes needing root
+  access, as well as the standard features that you might expect from a
+  process viewer.
+
+grade: stable # must be 'stable' to release into candidate/stable channels
+confinement: strict
+base: core22
+
+plugs:
+  run-systemd-sessions:
+    interface: system-files
+    read:
+    - /run/systemd/sessions
+
+slots:
+  # for GtkApplication registration
+  gnome-system-monitor:
+    interface: dbus
+    bus: session
+    name: org.gnome.SystemMonitor
+
+apps:
+  gnome-system-monitor:
+    extensions: [ gnome ]
+    command: usr/bin/gnome-system-monitor
+    plugs:
+      - unity7
+      - mount-observe
+      - network-observe
+      - hardware-observe
+      - system-observe
+      - process-control
+      - run-systemd-sessions
+    desktop: usr/share/applications/gnome-system-monitor.desktop
+    common-id: gnome-system-monitor.desktop
+
+parts:
+  gnome-system-monitor:
+    # ext:updatesnap
+    source: https://gitlab.gnome.org/GNOME/gnome-system-monitor.git
+    source-type: git
+    source-tag: '42.0'
+    source-depth: 1
+    plugin: meson
+    parse-info: [usr/share/metainfo/gnome-system-monitor.appdata.xml]
+    meson-parameters:
+      - --prefix=/snap/gnome-system-monitor/current/usr
+      - --buildtype=release
+      - -Dsystemd=true
+    organize:
+      snap/gnome-system-monitor/current/usr: usr
+    override-pull: |
+      craftctl default
+      craftctl set version=$(git describe --tags --abbrev=10)
+      sed -i.bak -e 's|Icon=org.gnome.SystemMonitor$|Icon=${SNAP}/meta/gui/org.gnome.SystemMonitor.svg|g' gnome-system-monitor.desktop.in.in
+      sed -i.bak -E -e 's|^(NotShowIn=.*)$|# \1|g' gnome-system-monitor.desktop.in.in
+    override-build: |
+      craftctl default
+      mkdir -p $CRAFT_PART_INSTALL/meta/gui/
+      cp $CRAFT_PART_BUILD/gnome-system-monitor.desktop $CRAFT_PART_INSTALL/meta/gui/
+      cp $CRAFT_PART_SRC/data/icons/public/hicolor/scalable/apps/org.gnome.SystemMonitor.svg $CRAFT_PART_INSTALL/meta/gui/
+    build-packages:
+      - desktop-file-utils
+      - docbook-to-man
+      - libgtop2-dev
+      - libsigc++-2.0-dev
+      - libsystemd-dev
+      - policykit-1
+      - yelp-tools
+    stage-packages:
+      - libsigc++-2.0-0v5
+
+  # workaround snapcraft trying to outsmart us by copying ldd listed libraries
+  libraries:
+    after: [gnome-system-monitor]
+    plugin: nil
+    stage-packages:
+      - libgtop-2.0-11
+    prime:
+      - "usr/lib/*/libgtop*"
+      - "usr/lib/*/libsigc-2.0.so.0*"
+
+  # Find files provided by the base and platform snap and ensure they aren't
+  # duplicated in this snap
+  cleanup:
+    after: [libraries]
+    plugin: nil
+    build-snaps: [core22, gnome-42-2204]
+    override-prime: |
+      set -eux
+      for snap in "core22" "gnome-42-2204"; do
+        cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$CRAFT_PRIME/{}" \;
+      done
+

--- a/updatesnap/tests/blank_line.yaml
+++ b/updatesnap/tests/blank_line.yaml
@@ -1,0 +1,105 @@
+name: gnome-system-monitor
+adopt-info: gnome-system-monitor
+summary: System Monitor
+description: |
+  GNOME System Monitor is a GNOME process viewer and system monitor with
+  an attractive, easy-to-use interface, It has features, such as a tree
+  view for process dependencies, icons for processes, the ability to hide
+  processes that you don't want to see, graphical time histories of
+  CPU/memory/swap usage, the ability to kill/renice processes needing root
+  access, as well as the standard features that you might expect from a
+  process viewer.
+
+grade: stable # must be 'stable' to release into candidate/stable channels
+confinement: strict
+base: core22
+
+build-snaps:
+  - gnome-42-2204/latest/candidate
+
+plugs:
+  run-systemd-sessions:
+    interface: system-files
+    read:
+    - /run/systemd/sessions
+
+slots:
+  # for GtkApplication registration
+  gnome-system-monitor:
+    interface: dbus
+    bus: session
+    name: org.gnome.SystemMonitor
+
+apps:
+  gnome-system-monitor:
+    extensions: [ gnome ]
+    command: usr/bin/gnome-system-monitor
+    plugs:
+      - unity7
+      - mount-observe
+      - network-observe
+      - hardware-observe
+      - system-observe
+      - process-control
+      - run-systemd-sessions
+    desktop: usr/share/applications/gnome-system-monitor.desktop
+    common-id: gnome-system-monitor.desktop
+
+parts:
+  gnome-system-monitor:
+
+    source: https://gitlab.gnome.org/GNOME/gnome-system-monitor.git
+    source-type: git
+    source-tag: '42.0'
+    source-depth: 1
+    plugin: meson
+    parse-info: [usr/share/metainfo/gnome-system-monitor.appdata.xml]
+    meson-parameters:
+      - --prefix=/snap/gnome-system-monitor/current/usr
+      - --buildtype=release
+      - -Dsystemd=true
+    organize:
+      snap/gnome-system-monitor/current/usr: usr
+    override-pull: |
+      craftctl default
+      craftctl set version=$(git describe --tags --abbrev=10)
+      sed -i.bak -e 's|Icon=org.gnome.SystemMonitor$|Icon=${SNAP}/meta/gui/org.gnome.SystemMonitor.svg|g' gnome-system-monitor.desktop.in.in
+      sed -i.bak -E -e 's|^(NotShowIn=.*)$|# \1|g' gnome-system-monitor.desktop.in.in
+    override-build: |
+      craftctl default
+      mkdir -p $CRAFT_PART_INSTALL/meta/gui/
+      cp $CRAFT_PART_BUILD/gnome-system-monitor.desktop $CRAFT_PART_INSTALL/meta/gui/
+      cp $CRAFT_PART_SRC/data/icons/public/hicolor/scalable/apps/org.gnome.SystemMonitor.svg $CRAFT_PART_INSTALL/meta/gui/
+    build-packages:
+      - desktop-file-utils
+      - docbook-to-man
+      - libgtop2-dev
+      - libsigc++-2.0-dev
+      - libsystemd-dev
+      - policykit-1
+      - yelp-tools
+    stage-packages:
+      - libsigc++-2.0-0v5
+
+  # workaround snapcraft trying to outsmart us by copying ldd listed libraries
+  libraries:
+    after: [gnome-system-monitor]
+    plugin: nil
+    stage-packages:
+      - libgtop-2.0-11
+    prime:
+      - "usr/lib/*/libgtop*"
+      - "usr/lib/*/libsigc-2.0.so.0*"
+
+  # Find files provided by the base and platform snap and ensure they aren't
+  # duplicated in this snap
+  cleanup:
+    after: [libraries]
+    plugin: nil
+    build-snaps: [core22, gnome-42-2204]
+    override-prime: |
+      set -eux
+      for snap in "core22" "gnome-42-2204"; do
+        cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$CRAFT_PRIME/{}" \;
+      done
+

--- a/updatesnap/tests/unaligned_comment.yaml
+++ b/updatesnap/tests/unaligned_comment.yaml
@@ -1,0 +1,105 @@
+name: gnome-system-monitor
+adopt-info: gnome-system-monitor
+summary: System Monitor
+description: |
+  GNOME System Monitor is a GNOME process viewer and system monitor with
+  an attractive, easy-to-use interface, It has features, such as a tree
+  view for process dependencies, icons for processes, the ability to hide
+  processes that you don't want to see, graphical time histories of
+  CPU/memory/swap usage, the ability to kill/renice processes needing root
+  access, as well as the standard features that you might expect from a
+  process viewer.
+
+grade: stable # must be 'stable' to release into candidate/stable channels
+confinement: strict
+base: core22
+
+build-snaps:
+  - gnome-42-2204/latest/candidate
+
+plugs:
+  run-systemd-sessions:
+    interface: system-files
+    read:
+    - /run/systemd/sessions
+
+slots:
+  # for GtkApplication registration
+  gnome-system-monitor:
+    interface: dbus
+    bus: session
+    name: org.gnome.SystemMonitor
+
+apps:
+  gnome-system-monitor:
+    extensions: [ gnome ]
+    command: usr/bin/gnome-system-monitor
+    plugs:
+      - unity7
+      - mount-observe
+      - network-observe
+      - hardware-observe
+      - system-observe
+      - process-control
+      - run-systemd-sessions
+    desktop: usr/share/applications/gnome-system-monitor.desktop
+    common-id: gnome-system-monitor.desktop
+
+parts:
+  gnome-system-monitor:
+# ext:updatesnap
+    source: https://gitlab.gnome.org/GNOME/gnome-system-monitor.git
+    source-type: git
+    source-tag: '42.0'
+    source-depth: 1
+    plugin: meson
+    parse-info: [usr/share/metainfo/gnome-system-monitor.appdata.xml]
+    meson-parameters:
+      - --prefix=/snap/gnome-system-monitor/current/usr
+      - --buildtype=release
+      - -Dsystemd=true
+    organize:
+      snap/gnome-system-monitor/current/usr: usr
+    override-pull: |
+      craftctl default
+      craftctl set version=$(git describe --tags --abbrev=10)
+      sed -i.bak -e 's|Icon=org.gnome.SystemMonitor$|Icon=${SNAP}/meta/gui/org.gnome.SystemMonitor.svg|g' gnome-system-monitor.desktop.in.in
+      sed -i.bak -E -e 's|^(NotShowIn=.*)$|# \1|g' gnome-system-monitor.desktop.in.in
+    override-build: |
+      craftctl default
+      mkdir -p $CRAFT_PART_INSTALL/meta/gui/
+      cp $CRAFT_PART_BUILD/gnome-system-monitor.desktop $CRAFT_PART_INSTALL/meta/gui/
+      cp $CRAFT_PART_SRC/data/icons/public/hicolor/scalable/apps/org.gnome.SystemMonitor.svg $CRAFT_PART_INSTALL/meta/gui/
+    build-packages:
+      - desktop-file-utils
+      - docbook-to-man
+      - libgtop2-dev
+      - libsigc++-2.0-dev
+      - libsystemd-dev
+      - policykit-1
+      - yelp-tools
+    stage-packages:
+      - libsigc++-2.0-0v5
+
+  # workaround snapcraft trying to outsmart us by copying ldd listed libraries
+  libraries:
+    after: [gnome-system-monitor]
+    plugin: nil
+    stage-packages:
+      - libgtop-2.0-11
+    prime:
+      - "usr/lib/*/libgtop*"
+      - "usr/lib/*/libsigc-2.0.so.0*"
+
+  # Find files provided by the base and platform snap and ensure they aren't
+  # duplicated in this snap
+  cleanup:
+    after: [libraries]
+    plugin: nil
+    build-snaps: [core22, gnome-42-2204]
+    override-prime: |
+      set -eux
+      for snap in "core22" "gnome-42-2204"; do
+        cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$CRAFT_PRIME/{}" \;
+      done
+


### PR DESCRIPTION
When a comment is unaligned with the rest of the YAML code, or there is a blank line dividing a group, the parser fails.

This patch fixes it and adds three extra tests.

Fix https://github.com/ubuntu/desktop-snaps/issues/116