### PR TITLE
Don't fail if the snapcraft file is in snap/ folder

### DIFF
--- a/updatesnap/updatesnapyaml.py
+++ b/updatesnap/updatesnapyaml.py
@@ -47,10 +47,13 @@ class ProjectManager:
         try:
             data = self._github.get_file(project_url, yaml_path)
         except (ValueError, ConnectionError):
-            return None
+            data = None
         if not data:
             yaml_path = 'snap/snapcraft.yaml'
-            data = self._github.get_file(project_url, yaml_path)
+            try:
+                data = self._github.get_file(project_url, yaml_path)
+            except (ValueError, ConnectionError):
+                data = None
         return data
 
 


### PR DESCRIPTION
If the snapcraft.yaml file is inside the snap/ folder, it fails to download it. This patch fixes it.

Fix https://github.com/ubuntu/desktop-snaps/issues/115