### PR TITLE
Candidate check on stable

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -15,8 +15,6 @@ jobs:
          working-directory: candidate-snaps-review
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: candidate-check
       - name: Review new candidates
         id: review
         run: ./candidate-snaps-review.py

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   refresh:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/candidate-check'
     defaults:
       run:
          working-directory: candidate-snaps-review

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -14,6 +14,8 @@ jobs:
          working-directory: candidate-snaps-review
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: candidate-check
       - name: Review new candidates
         id: review
         run: ./candidate-snaps-review.py

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   refresh:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/candidate-check'
     defaults:
       run:
          working-directory: candidate-snaps-review

--- a/candidate-snaps-review/candidate.yml
+++ b/candidate-snaps-review/candidate.yml
@@ -2,14 +2,11 @@ cheese: []
 cherrytree: []
 chromium:
 - 2450
-eog:
-- 708
+eog: []
 epiphany:
 - 145
-evince:
-- 1027
-firefox:
-- 2605
+evince: []
+firefox: []
 five-or-more: []
 gedit: []
 glade: []
@@ -24,24 +21,20 @@ gnome-3-38-2004:
 - 140
 gnome-3-38-2004-sdk: []
 gnome-42-2204:
-- 94
-gnome-42-2204-sdk:
-- 122
+- 102
+gnome-42-2204-sdk: []
 gnome-boxes:
 - 3
-gnome-calculator:
-- 934
+gnome-calculator: []
 gnome-calendar: []
-gnome-characters:
-- 785
+gnome-characters: []
 gnome-chess: []
 gnome-clocks:
 - 455
 gnome-contacts:
-- 187
+- 190
 gnome-dictionary: []
-gnome-font-viewer:
-- 43
+gnome-font-viewer: []
 gnome-hitori: []
 gnome-klotski: []
 gnome-logs: []

--- a/candidate-snaps-review/candidate.yml
+++ b/candidate-snaps-review/candidate.yml
@@ -18,8 +18,7 @@ gnome-3-34-1804: []
 gnome-3-34-1804-sdk: []
 gnome-3-38-2004: []
 gnome-3-38-2004-sdk: []
-gnome-42-2204:
-- 102
+gnome-42-2204: []
 gnome-42-2204-sdk: []
 gnome-boxes:
 - 3

--- a/candidate-snaps-review/candidate.yml
+++ b/candidate-snaps-review/candidate.yml
@@ -14,18 +14,17 @@ glimpse-editor: []
 gnome-2048: []
 gnome-3-26-1604: []
 gnome-3-28-1804: []
-gnome-3-34-1804:
-- 93
+gnome-3-34-1804: []
 gnome-3-34-1804-sdk: []
-gnome-3-38-2004:
-- 140
+gnome-3-38-2004: []
 gnome-3-38-2004-sdk: []
 gnome-42-2204:
 - 102
 gnome-42-2204-sdk: []
 gnome-boxes:
 - 3
-gnome-calculator: []
+gnome-calculator:
+- 936
 gnome-calendar: []
 gnome-characters: []
 gnome-chess: []

--- a/candidate-snaps-review/candidate.yml
+++ b/candidate-snaps-review/candidate.yml
@@ -1,12 +1,12 @@
 cheese: []
 cherrytree: []
 chromium:
-- 2450
+- 2459
 eog: []
-epiphany:
-- 145
+epiphany: []
 evince: []
-firefox: []
+firefox:
+- 2645
 five-or-more: []
 gedit: []
 glade: []
@@ -18,8 +18,10 @@ gnome-3-34-1804: []
 gnome-3-34-1804-sdk: []
 gnome-3-38-2004: []
 gnome-3-38-2004-sdk: []
-gnome-42-2204: []
-gnome-42-2204-sdk: []
+gnome-42-2204:
+- 102
+gnome-42-2204-sdk:
+- 131
 gnome-boxes:
 - 3
 gnome-calculator:
@@ -45,17 +47,15 @@ gnome-sudoku: []
 gnome-system-monitor: []
 gnome-taquin: []
 gnome-tetravex: []
-gnome-text-editor:
-- 18
+gnome-text-editor: []
 gtk-common-themes: []
 iagno: []
-libreoffice:
-- 274
+libreoffice: []
 lightsoff: []
 quadrapassel: []
 snap-store: []
 swell-foop: []
 tali: []
 thunderbird:
-- 319
+- 323
 ubuntu-desktop-installer: []


### PR DESCRIPTION
The re-enables the candidate check workflow on the stable branch.  For this to work, we need to disable the branch protection rules.