### PR TITLE
Check for malformed #ext: updatesnap elements

### DIFF
--- a/updatesnap/tests/snapcraft_no_true_false.yaml
+++ b/updatesnap/tests/snapcraft_no_true_false.yaml
@@ -1,0 +1,58 @@
+name: swell-foop
+adopt-info: swell-foop
+grade: stable # must be 'stable' to release into candidate/stable channels
+confinement: strict
+base: core22
+
+slots:
+  # for GtkApplication registration
+  swell-foop:
+    interface: dbus
+    bus: session
+    name: org.gnome.SwellFoop
+
+layout:
+ /usr/share/swell-foop:
+   symlink: $SNAP/usr/share/swell-foop
+
+apps:
+  swell-foop:
+    command: bin/snapcraft-preload $SNAP/usr/bin/swell-foop
+    extensions: [gnome]
+    plugs:
+      - opengl
+    desktop: usr/share/applications/org.gnome.SwellFoop.desktop
+    common-id: org.gnome.SwellFoop.desktop
+    environment:
+      GSETTINGS_SCHEMA_DIR: $SNAP/share/glib-2.0/schemas
+      DISABLE_WAYLAND: 'true'
+
+parts:
+  snapcraft-preload:
+# ext:updatesnap
+#   version-format:
+#     allow-neither-tag-nor-branch
+    source: https://github.com/sergiusens/snapcraft-preload.git
+    source-depth: 1
+    plugin: cmake
+    cmake-parameters:
+      - -DCMAKE_INSTALL_PREFIX=/
+    build-packages:
+      - on amd64:
+        - gcc-multilib
+        - g++-multilib
+
+  swell-foop:
+    source: https://gitlab.gnome.org/GNOME/swell-foop.git
+    source-type: git
+    source-tag: '41.1'
+    source-depth: 1
+    plugin: meson
+    meson-parameters:
+      - --prefix=/usr
+    parse-info: [usr/share/metainfo/org.gnome.SwellFoop.appdata.xml]
+    override-build: |
+      sed -i.bak -e 's|Icon=org.gnome.SwellFoop$|Icon=${SNAP}/meta/gui/org.gnome.SwellFoop.png|g' $CRAFT_PART_SRC/data/org.gnome.SwellFoop.desktop.in
+      craftctl default
+      mkdir -p $CRAFT_PART_INSTALL/meta/gui/
+      cp $CRAFT_PART_SRC/data/icons/hicolor/512x512/apps/org.gnome.SwellFoop.png $CRAFT_PART_INSTALL/meta/gui/

--- a/updatesnap/unittests.py
+++ b/updatesnap/unittests.py
@@ -15,6 +15,7 @@ from SnapModule.snapmodule import Gitlab
 
 
 class TestYAMLfiles(unittest.TestCase):
+    # pylint: disable=too-many-public-methods
     """ Unitary tests for snapmodule """
 
     def _load_secrets(self, obj):
@@ -267,7 +268,6 @@ class TestYAMLfiles(unittest.TestCase):
         data = self._base_load_test_file("aligned_comment.yaml")
         yaml_obj = ManageYAML(data)
         element = yaml_obj.get_part_element('gnome-system-monitor', 'source')
-        print(element)
         assert isinstance(element, dict)
         assert 'data' in element
         assert element['data'] == 'source: https://gitlab.gnome.org/GNOME/gnome-system-monitor.git'
@@ -302,6 +302,14 @@ class TestYAMLfiles(unittest.TestCase):
         assert element['level'] == 2
         assert 'separator' in element
         assert element['separator'] == '    '
+
+    def test_no_true_or_false_on_option(self):
+        """ Checks if the file doesn't follow the right format """
+        data = self._base_load_test_file("snapcraft_no_true_false.yaml")
+        snap = Snapcraft(True)
+        with self.assertRaises(ValueError) as context:
+            snap.load_external_data(data)
+        assert context.exception
 
 
 class GitPose:


### PR DESCRIPTION
This patch ensures that the '#ext: updatesnap' content is a dictionary, to detect common errors like putting an option without the mandatory ": true" postfix.

Fix https://github.com/ubuntu/desktop-snaps/issues/153