### PR TITLE
Remove unneeded output during unitests

### DIFF
--- a/updatesnap/SnapModule/snapmodule.py
+++ b/updatesnap/SnapModule/snapmodule.py
@@ -53,6 +53,12 @@ class ProcessVersion:
         self._colors = Colors()
         self._last_part = None
         self._error_list = []
+        self._full_silent = False
+
+    def set_full_silent(self):
+        """ Fully disables all the messages, not only the warnings or
+            the current process. Useful for testings."""
+        self._full_silent = True
 
     def _print_message(self, part, message, source=None, override_silent=False):
         # pylint: disable=too-many-function-args
@@ -63,6 +69,8 @@ class ProcessVersion:
     def _print_error(self, part, use_color, message, source=None, extra_cr=False):
         # pylint: disable=too-many-arguments
         self._error_list.append(message)
+        if self._full_silent:
+            return
         if part != self._last_part:
             print(f"Part: {self._colors.note}{part}{self._colors.reset}"
                   f"{f' ({source})' if source else ''}", file=sys.stderr)
@@ -466,6 +474,11 @@ class Snapcraft(ProcessVersion):
             self._gitlab = gitlab_pose
         else:
             self._gitlab = Gitlab(silent)
+
+    def set_full_silent(self):
+        super().set_full_silent()
+        self._github.set_full_silent()
+        self._gitlab.set_full_silent()
 
     def set_secret(self, backend, key, value):
         """ Sets an specific secret value for a backend """

--- a/updatesnap/unittests.py
+++ b/updatesnap/unittests.py
@@ -51,6 +51,7 @@ class TestYAMLfiles(unittest.TestCase):
         gitlab_pose.set_tags(tags)
         gitlab_pose.set_branches(branches)
         snap = Snapcraft(True, github_pose, gitlab_pose)
+        snap.set_full_silent()
         snap.load_external_data(data)
         return snap, data, github_pose, gitlab_pose
 
@@ -122,6 +123,7 @@ class TestYAMLfiles(unittest.TestCase):
         # pylint: disable=protected-access
         """ Test the no-9x-revision option """
         obj = ProcessVersion(silent=True)
+        obj.set_full_silent()
         entry_format = {"format": "%M.%m.%R", "no-9x-revisions": True}
         version = obj._get_version("testpart", "3.8.92", entry_format, False)
         assert version is None
@@ -132,6 +134,7 @@ class TestYAMLfiles(unittest.TestCase):
         # pylint: disable=protected-access
         """ Test the no-9x-minors option """
         obj = ProcessVersion(silent=True)
+        obj.set_full_silent()
         entry_format = {"format": "%M.%m.%R", "no-9x-minors": True}
         version = obj._get_version("testpart", "3.97.1", entry_format, False)
         assert version is None
@@ -142,6 +145,7 @@ class TestYAMLfiles(unittest.TestCase):
         # pylint: disable=protected-access
         """ Tests the "ignore-odd-minor" option when parsing versions """
         obj = ProcessVersion(silent=True)
+        obj.set_full_silent()
         entry_format = {"format": "%M.%m.%R", "ignore-odd-minor": True}
         version = obj._get_version("testpart", "2.43.6", entry_format, False)
         assert version is None
@@ -151,6 +155,7 @@ class TestYAMLfiles(unittest.TestCase):
     def test_github_file_download(self):
         """ Check that a file download from github works as expected """
         gitobj = Github(silent=True)
+        gitobj.set_full_silent()
         self._load_secrets(gitobj)
         data = gitobj.get_file("https://github.com/ubuntu/gnome-calculator", "snapcraft.yaml")
         assert data is not None
@@ -162,6 +167,7 @@ class TestYAMLfiles(unittest.TestCase):
     def test_github_tags_download(self):
         """ Check that tag download from github works as expected """
         gitobj = Github(silent=True)
+        gitobj.set_full_silent()
         self._load_secrets(gitobj)
         data = gitobj.get_tags("https://github.com/GNOME/gnome-calculator",
                                "40.0", {"format": "%M.%m"})
@@ -187,6 +193,7 @@ class TestYAMLfiles(unittest.TestCase):
     def test_gitlab_tags_download(self):
         """ Check that tag download from gitlab works as expected """
         gitobj = Gitlab(silent=True)
+        gitobj.set_full_silent()
         self._load_secrets(gitobj)
         data = gitobj.get_tags("https://gitlab.gnome.org/GNOME/gnome-calculator",
                                "40.0", {"format": "%M.%m"})
@@ -308,6 +315,7 @@ class TestYAMLfiles(unittest.TestCase):
         """ Checks if the file doesn't follow the right format """
         data = self._base_load_test_file("snapcraft_no_true_false.yaml")
         snap = Snapcraft(True)
+        snap.set_full_silent()
         with self.assertRaises(ValueError) as context:
             snap.load_external_data(data)
         assert context.exception
@@ -316,6 +324,7 @@ class TestYAMLfiles(unittest.TestCase):
         # pylint: disable=protected-access
         """ Tests the "ignore-version" option when parsing a version as a string """
         obj = ProcessVersion(silent=True)
+        obj.set_full_silent()
         entry_format = {"format": "%M.%m.%R", "ignore-version": "2.43.6"}
         version = obj._get_version("testpart", "2.43.6", entry_format, False)
         assert version is None
@@ -330,6 +339,7 @@ class TestYAMLfiles(unittest.TestCase):
         # pylint: disable=protected-access
         """ Tests the "ignore-version" option when parsing a version as a list of versions """
         obj = ProcessVersion(silent=True)
+        obj.set_full_silent()
         entry_format = {"format": "%M.%m.%R", "ignore-version": ["2.43.6", "3.2.4"]}
         version = obj._get_version("testpart", "2.43.6", entry_format, False)
         assert version is None
@@ -355,6 +365,7 @@ class TestYAMLfiles(unittest.TestCase):
         """ Tests that "ignore-version" shows an error when the version is neither
             a string nor a list """
         obj = ProcessVersion(silent=True)
+        obj.set_full_silent()
         entry_format = {"format": "%M.%m.%R", "ignore-version": {}}
         with self.assertRaises(ValueError) as context:
             obj._get_version("testpart", "2.43.6", entry_format, False)
@@ -369,6 +380,7 @@ class TestYAMLfiles(unittest.TestCase):
         """ Tests that "ignore-version" shows an error when the version is neither
             a string or a list """
         obj = ProcessVersion(silent=True)
+        obj.set_full_silent()
         entry_format = {"format": "%M.%m.%R", "ignore-version": ["1.3.4", ["4.5", "8"]]}
         with self.assertRaises(ValueError) as context:
             obj._get_version("testpart", "2.43.6", entry_format, False)
@@ -387,6 +399,12 @@ class GitPose:
         self._tags = {}
         self._branches = {}
         self._uri_error = None
+        self._silent = True
+        self._full_silent = False
+
+    def set_full_silent(self):
+        """ Implements the method to avoid errors. """
+        self._full_silent = True
 
     def set_uri_error(self, new_uri_error: Exception):
         """ Sets whether the object will emulate an error in the URI or

--- a/updatesnap/unittests.py
+++ b/updatesnap/unittests.py
@@ -200,9 +200,9 @@ class TestYAMLfiles(unittest.TestCase):
         assert isinstance(data, list)
         # ensure that the known tags are in the list
         tags = get_gnome_calculator_tags()["https://gitlab.gnome.org/GNOME/gnome-calculator.git"]
-        for tag in data:
+        for tag in tags:
             found = False
-            for tag2 in tags:
+            for tag2 in data:
                 if tag2["name"] == tag["name"]:
                     found = True
                     break
@@ -787,10 +787,6 @@ def get_gnome_calculator_tags():
                                             datetime.timedelta(seconds=10800)))},
                 {'name': '40.0',
                  'date': datetime.datetime(2021, 3, 19, 20, 32, 6,
-                                           tzinfo=datetime.timezone(
-                                            datetime.timedelta(seconds=7200)))},
-                {'name': '40.rc',
-                 'date': datetime.datetime(2021, 3, 12, 19, 32, 25,
                                            tzinfo=datetime.timezone(
                                             datetime.timedelta(seconds=7200)))}
             ]


### PR DESCRIPTION
Previously, during the unitary tests, there were a lot of unneeded messages on screen. This patch fixes it.