### PR TITLE
add github action and script to check for broken builds in launchpad

### DIFF
--- a/.github/workflows/check-builds.yml
+++ b/.github/workflows/check-builds.yml
@@ -1,0 +1,19 @@
+name: Check for broken builds
+
+on:
+  schedule:
+    # Daily for now
+    - cron: '9 7 * * *'
+  workflow_dispatch:
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+         working-directory: candidate-snaps-review
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check for broken builds
+        id: check-builds
+        run: ./check-builds.py ${{ secrets.GITHUB_TOKEN }}

--- a/candidate-snaps-review/check-builds.py
+++ b/candidate-snaps-review/check-builds.py
@@ -1,0 +1,75 @@
+#!/usr/bin/python3
+
+import json
+import re
+import sys
+import urllib.request
+
+import snaps
+
+req = urllib.request.Request("https://api.github.com/repos/ubuntu/desktop-snaps/issues")
+issues = json.load(urllib.request.urlopen(req))
+
+def get_builds(launchpad_url):
+    req = urllib.request.Request(launchpad_url)
+    builds_res = urllib.request.urlopen(req)
+
+    builds = json.load(builds_res)
+    arch = dict()
+    i=0
+    while(builds["entries"][i]["arch_tag"] not in arch):
+        arch[builds["entries"][i]["arch_tag"]] = False if builds["entries"][i]["buildstate"] == "Failed to build" else True
+        i+=1
+    return arch
+
+def open_issue(name, arch, url):            
+    data = {
+        "title": "%s build on %s is broken" % (name, arch),
+        "body": "The last attempt to build %s on %s failed. Launchpad is reporting a \"Failed to build\" status. \n %s" % (name, arch, url),
+        }
+    headers = {
+        "authorization": "Bearer %s" % sys.argv[1],
+        }
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/ubuntu/desktop-snaps/issues",
+        method="POST",
+        headers=headers,
+        data=bytes(json.dumps(data), encoding="utf-8"),
+    )
+    urllib.request.urlopen(req)
+
+def check_for_issues(name, arch):
+    for entry in issues:
+        title = entry["title"]
+        regexp = re.compile(r"(.*) build on (.*) is broken")
+        parsed = regexp.search(title)
+        if parsed:
+            issue_name, issue_arch = parsed.groups()
+            if issue_name == name and issue_arch == arch:
+              return entry["number"]
+    return 0
+
+
+def close_issue(n):            
+    close_data = {"state": "closed"}
+    headers = {
+        "authorization": "Bearer %s" % sys.argv[1],
+        }
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/ubuntu/desktop-snaps/issues/{n}",
+        method="PATCH",
+        headers=headers,
+        data=bytes(json.dumps(close_data), encoding="utf-8"),
+    )
+    urllib.request.urlopen(req)
+      
+# iterate over the list of snaps
+for snapline in snaps.normalsnaps + snaps.specialsnaps:
+    if(snapline[1] != None):
+        response = get_builds(snapline[1].replace("launchpad.net", "api.launchpad.net/1.0")+"/builds")
+        for arch, result in response.items():
+            issue = check_for_issues(snapline[0], arch)
+            if issue != 0 and result:
+                close_issue(issue)
+            elif issue == 0 and not result:
+                open_issue(snapline[0], arch, snapline[1])


### PR DESCRIPTION
This change will open an issue per snap and per architecture where a "Failed to build" status is reported by launchpad.
It will auto close when the build is back to "Built successfully".
