### PR TITLE
refactor actions and code to work on forks

### DIFF
--- a/.github/workflows/check-builds.yml
+++ b/.github/workflows/check-builds.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: actions/checkout@v3
       - name: Check for broken builds
         id: check-builds
-        run: ./check-builds.py ${{ secrets.GITHUB_TOKEN }}
+        run: ./check-builds.py https://api.github.com/repos/${{ github.repository }}/issues ${{ secrets.GITHUB_TOKEN }}

--- a/candidate-snaps-review/check-builds.py
+++ b/candidate-snaps-review/check-builds.py
@@ -7,7 +7,7 @@ import urllib.request
 
 import snaps
 
-req = urllib.request.Request("https://api.github.com/repos/ubuntu/desktop-snaps/issues")
+req = urllib.request.Request(sys.argv[1])
 issues = json.load(urllib.request.urlopen(req))
 
 def get_builds(launchpad_url):
@@ -28,10 +28,10 @@ def open_issue(name, arch, url):
         "body": "The last attempt to build %s on %s failed. Launchpad is reporting a \"Failed to build\" status. \n %s" % (name, arch, url),
         }
     headers = {
-        "authorization": "Bearer %s" % sys.argv[1],
+        "authorization": "Bearer %s" % sys.argv[2],
         }
     req = urllib.request.Request(
-        f"https://api.github.com/repos/ubuntu/desktop-snaps/issues",
+        sys.argv[1],
         method="POST",
         headers=headers,
         data=bytes(json.dumps(data), encoding="utf-8"),
@@ -53,10 +53,10 @@ def check_for_issues(name, arch):
 def close_issue(n):            
     close_data = {"state": "closed"}
     headers = {
-        "authorization": "Bearer %s" % sys.argv[1],
+        "authorization": "Bearer %s" % sys.argv[2],
         }
     req = urllib.request.Request(
-        f"https://api.github.com/repos/ubuntu/desktop-snaps/issues/{n}",
+        sys.argv[1]+f"/{n}",
         method="PATCH",
         headers=headers,
         data=bytes(json.dumps(close_data), encoding="utf-8"),

--- a/candidate-snaps-review/close-fixed-issues.py
+++ b/candidate-snaps-review/close-fixed-issues.py
@@ -37,14 +37,14 @@ for entry in json.load(issues):
             print("Closing issue %s since %s r%s isn't in %scandidate anymore" % (n, source, rev, track))
 
             req = urllib.request.Request(
-                f"https://api.github.com/repos/ubuntu/desktop-snaps/issues/{n}/comments",
+                sys.argv[1]+f"/{n}/comments",
                 method="POST",
                 headers=headers,
                 data=bytes(json.dumps(msg_data), encoding="utf-8"),
             )
             urllib.request.urlopen(req)
             req = urllib.request.Request(
-                f"https://api.github.com/repos/ubuntu/desktop-snaps/issues/{n}",
+                sys.argv[1]+f"/{n}",
                 method="PATCH",
                 headers=headers,
                 data=bytes(json.dumps(close_data), encoding="utf-8"),


### PR DESCRIPTION
Currently both candidate review and check builds github actions fail when the repo is forked. This is due to hardcoded paths to the ubuntu/desktop-snaps repo. This change refactors the code so the repo is passed as a parameter by the github action.