### PR TITLE
ci: Add Jira sync action

### DIFF
--- a/.github/workflows/jira-sync.yml
+++ b/.github/workflows/jira-sync.yml
@@ -1,0 +1,13 @@
+name: Sync GitHub issues to Jira
+on: [issues, issue_comment]
+
+jobs:
+  sync-issues:
+    name: Sync issues to Jira
+    runs-on: ubuntu-latest
+    steps:
+      - uses: canonical/sync-issues-github-jira@v1
+        with:
+          webhook-url: ${{ secrets.JIRA_WEBHOOK_URL }}
+          component: 'Snap'
+          label: 'jira'


### PR DESCRIPTION
Github action to create a ticket under the Snap component whenever the Jira label is added to an issue. 
This can help us bring snap testing, broken builds or issues in general into Jira.

For this to work someone with the right repo access needs to create the `JIRA_WEBHOOK_URL` secret