### PR TITLE
[Add] Versions variation and beta-releases support

### DIFF
--- a/candidate-snaps-review/candidate.yml
+++ b/candidate-snaps-review/candidate.yml
@@ -1,5 +1,4 @@
-cheese:
-- 40
+cheese: []
 cherrytree: []
 chromium: []
 eog: []
@@ -21,16 +20,14 @@ gnome-3-38-2004-sdk: []
 gnome-42-2204:
 - 166
 gnome-42-2204-sdk: []
-gnome-boxes:
-- 11
+gnome-boxes: []
 gnome-calculator: []
 gnome-calendar: []
 gnome-characters: []
 gnome-chess: []
-gnome-clocks:
-- 465
+gnome-clocks: []
 gnome-contacts:
-- 212
+- 215
 gnome-dictionary: []
 gnome-font-viewer: []
 gnome-hitori: []
@@ -41,13 +38,11 @@ gnome-mines: []
 gnome-nibbles: []
 gnome-recipes: []
 gnome-robots: []
-gnome-sudoku:
-- 108
+gnome-sudoku: []
 gnome-system-monitor: []
 gnome-taquin: []
 gnome-tetravex: []
-gnome-text-editor:
-- 37
+gnome-text-editor: []
 gtk-common-themes: []
 iagno: []
 kisak-fresh/gaming-graphics-core22:
@@ -63,7 +58,6 @@ snap-store:
 steam: []
 swell-foop: []
 tali: []
-thunderbird:
-- 429
+thunderbird: []
 ubuntu-desktop-installer:
 - 1280

--- a/candidate-snaps-review/candidate.yml
+++ b/candidate-snaps-review/candidate.yml
@@ -5,7 +5,8 @@ chromium: []
 eog: []
 epiphany: []
 evince: []
-firefox: []
+firefox:
+- 3626
 five-or-more: []
 gedit: []
 glade: []
@@ -49,8 +50,10 @@ gnome-text-editor:
 - 37
 gtk-common-themes: []
 iagno: []
-kisak-fresh/gaming-graphics-core22: []
-kisak-turtle/gaming-graphics-core22: []
+kisak-fresh/gaming-graphics-core22:
+- 147
+kisak-turtle/gaming-graphics-core22:
+- 146
 libreoffice: []
 lightsoff: []
 oibaf-latest/gaming-graphics-core22: []
@@ -62,4 +65,5 @@ swell-foop: []
 tali: []
 thunderbird:
 - 429
-ubuntu-desktop-installer: []
+ubuntu-desktop-installer:
+- 1280

--- a/updatesnap/README.md
+++ b/updatesnap/README.md
@@ -126,6 +126,10 @@ The available extra tokens are:
   The %M token specifies where is the Major value; the %m specifies the minor, and
   the %R the revision.
 
+  Format can also be defined in form of "%V" or "prefix/%V". The %V token indicates variation in versions or beta-releases.
+  For example if tags follows format "1.0b2" or "debian/3.22.10+dfsg0-4", then token should be:
+    format: "%V" or format: "debian/%V" respectively 
+
   If the format is "%M.%m.%R", "%M.%m" or "v%M.%m.%R", *update_snap* will autodetect
   it, so in those cases it can be skipped.
 * lower-than: followed by a version number in %M.%m.%R format, specifies that the only

--- a/updatesnap/SnapModule/snapmodule.py
+++ b/updatesnap/SnapModule/snapmodule.py
@@ -117,7 +117,9 @@ class ProcessVersion:
             return None  # unknown format
         # Check for variations in the version format and beta releases.
         if '%V' in entry_format['format']:
-            version = pkg_resources.parse_version(entry.split("/")[-1])
+            if not entry.startswith(entry_format['format'].split('%')[0]):
+                return None
+            version = pkg_resources.parse_version(entry[len(entry_format['format'].split('%')[0]):])
             if (("lower-than" in entry_format) and
                     (version >= pkg_resources.parse_version(str(entry_format["lower-than"])))):
                 return None
@@ -401,9 +403,6 @@ class Gitlab(GitClass):
         """ Evaluates the URI of a repository and returns an URI
             object with it, but only if it is a Gitlab URI. """
         uri = self._get_uri(repository, 3)
-        # Check for gitlab instance used by debian
-        if "salsa" in uri.netloc:
-            return uri
         if "gitlab" not in uri.netloc:
             return None
         return uri
@@ -677,7 +676,7 @@ class Snapcraft(ProcessVersion):
 
         if ("format" not in version_format) and (current_tag is not None):
             # if the version format is not specified,
-            # automatically detect it between any of these common formats:
+            # automagically detect it between any of these common formats:
             # * %M.%m.%R
             # * v%M.%m.%R
             # * %M.%m

--- a/updatesnap/SnapModule/snapmodule.py
+++ b/updatesnap/SnapModule/snapmodule.py
@@ -116,11 +116,10 @@ class ProcessVersion:
                                   f"{part_name}.")
             return None  # unknown format
         # Check for variations in the version format and beta releases.
-        if ('%V' in entry_format['format']):
-            version_part = entry.split("/")[-1]
-            version = pkg_resources.parse_version(version_part)
+        if '%V' in entry_format['format']:
+            version = pkg_resources.parse_version(entry.split("/")[-1])
             if (("lower-than" in entry_format) and
-                (version >= pkg_resources.parse_version(str(entry_format["lower-than"])))):
+                    (version >= pkg_resources.parse_version(str(entry_format["lower-than"])))):
                 return None
             return version
         major = 0
@@ -402,7 +401,7 @@ class Gitlab(GitClass):
         """ Evaluates the URI of a repository and returns an URI
             object with it, but only if it is a Gitlab URI. """
         uri = self._get_uri(repository, 3)
-        ## Check for gitlab instance used by debian
+        # Check for gitlab instance used by debian
         if "salsa" in uri.netloc:
             return uri
         if "gitlab" not in uri.netloc:


### PR DESCRIPTION
- The "snapmodule.py" script has been revised to incorporate a new format token, namely '%V' and its prefixed version "prefix/%V."

- This token is applicable in cases where tag versions deviate from the standard or exhibit uncommon characteristics, such as containing alphanumeric values or exceeding three integers.

- When the tag version adheres to the format "1.0b2," the recommended token is specified as `format: "%V"`

- In the scenario where the tag version is structured as "debian/3.22.10+dfsg0-4," it is advised to employ the `format: "debian/%V" `token.