### PR TITLE
[Add] support for debian instance of gitlab

### DIFF
--- a/updatesnap/SnapModule/snapmodule.py
+++ b/updatesnap/SnapModule/snapmodule.py
@@ -394,6 +394,9 @@ class Gitlab(GitClass):
         """ Evaluates the URI of a repository and returns an URI
             object with it, but only if it is a Gitlab URI. """
         uri = self._get_uri(repository, 3)
+        # Check for gitlab instance used by debian
+        if "salsa" in uri.netloc:
+            return uri
         if "gitlab" not in uri.netloc:
             return None
         return uri


### PR DESCRIPTION
- GitLab offers robust support for Debian instances, ensuring seamless integration and compatibility with Debian-based systems. This support extends to efficient package management, enabling users to effortlessly deploy and manage GitLab on Debian platforms. Users can leverage GitLab's comprehensive features while enjoying a reliable and optimized experience within the Debian ecosystem.