### PR TITLE
[Fixes] Unit-tests

### DIFF
--- a/updatesnap/unittests.py
+++ b/updatesnap/unittests.py
@@ -174,6 +174,8 @@ class TestYAMLfiles(unittest.TestCase):
         assert isinstance(data, list)
         # ensure that the known tags are in the list
         tags = get_gnome_calculator_tags()["https://gitlab.gnome.org/GNOME/gnome-calculator.git"]
+        # retrieve latest tags but checks only last tags-length data elements
+        data = data[len(data)-len(tags):]
         for tag in data:
             found = False
             for tag2 in tags:


### PR DESCRIPTION
- updated `'test_github_tags_download'` in unit tests so that it exclusively consider the most recent tag related to the length of tags in the `'get_gnome_calculator_tags.'` This adjustment is necessary as the current unit tests are encountering errors due to an outdated tag list in `'get_gnome_calculator_tags.'`