### PR TITLE
[Add]: support for non PEP 440 spec versions

### DIFF
--- a/.github/workflows/updatesnaptests.yml
+++ b/.github/workflows/updatesnaptests.yml
@@ -24,6 +24,7 @@ jobs:
         python3 -m pip install flake8
         python3 -m pip install requests
         python3 -m pip install pyyaml
+        python3 -m pip install python-debian
     - name: Code tests
       env:
         GITHUB_USER: ubuntu

--- a/.github/workflows/updatesnaptests.yml
+++ b/.github/workflows/updatesnaptests.yml
@@ -25,6 +25,7 @@ jobs:
         python3 -m pip install requests
         python3 -m pip install pyyaml
         python3 -m pip install python-debian
+        python3 -m pip install packaging
     - name: Code tests
       env:
         GITHUB_USER: ubuntu

--- a/updatesnap/SnapModule/snapmodule.py
+++ b/updatesnap/SnapModule/snapmodule.py
@@ -14,6 +14,7 @@ import requests
 import yaml
 
 import pkg_resources
+import debian.debian_support
 
 
 class Colors:
@@ -119,11 +120,22 @@ class ProcessVersion:
         if '%V' in entry_format['format']:
             if not entry.startswith(entry_format['format'].split('%')[0]):
                 return None
-            version = pkg_resources.parse_version(entry[len(entry_format['format'].split('%')[0]):])
-            if (("lower-than" in entry_format) and
-                    (version >= pkg_resources.parse_version(str(entry_format["lower-than"])))):
-                return None
-            return version
+            try:
+                version = pkg_resources.parse_version(
+                        entry[len(entry_format['format'].split('%')[0]):])
+                if (("lower-than" in entry_format) and
+                        (version >= pkg_resources.parse_version(
+                            str(entry_format["lower-than"])))):
+                    return None
+                return version
+            except pkg_resources.extern.packaging.version.InvalidVersion:
+                version = debian.debian_support.Version(
+                    entry[len(entry_format['format'].split('%')[0]):])
+                if (("lower-than" in entry_format) and
+                        (version >= debian.debian_support.Version(
+                            str(entry_format["lower-than"])))):
+                    return None
+                return version
         major = 0
         minor = 0
         revision = 0

--- a/updatesnap/SnapModule/snapmodule.py
+++ b/updatesnap/SnapModule/snapmodule.py
@@ -13,7 +13,7 @@ from typing import Optional
 import requests
 import yaml
 
-import pkg_resources
+import packaging.version
 import debian.debian_support
 
 
@@ -121,14 +121,14 @@ class ProcessVersion:
             if not entry.startswith(entry_format['format'].split('%')[0]):
                 return None
             try:
-                version = pkg_resources.parse_version(
+                version = packaging.version.parse(
                         entry[len(entry_format['format'].split('%')[0]):])
                 if (("lower-than" in entry_format) and
-                        (version >= pkg_resources.parse_version(
+                        (version >= packaging.version.parse(
                             str(entry_format["lower-than"])))):
                     return None
                 return version
-            except pkg_resources.extern.packaging.version.InvalidVersion:
+            except packaging.version.InvalidVersion:
                 version = debian.debian_support.Version(
                     entry[len(entry_format['format'].split('%')[0]):])
                 if (("lower-than" in entry_format) and
@@ -159,12 +159,12 @@ class ProcessVersion:
             if not entry.startswith(part):
                 return None
             entry = entry[len(part):]
-        version = pkg_resources.parse_version(f"{major}.{minor}.{revision}")
+        version = packaging.version.parse(f"{major}.{minor}.{revision}")
 
         if "ignore-version" in entry_format:
             to_ignore = entry_format["ignore-version"]
             if isinstance(to_ignore, str):
-                if version == pkg_resources.parse_version(to_ignore):
+                if version == packaging.version.parse(to_ignore):
                     return None
             elif isinstance(to_ignore, list):
                 for ignore_version in to_ignore:
@@ -173,7 +173,7 @@ class ProcessVersion:
                                    "contains an element that is not a string.")
                         self._print_error(part_name, self._colors.critical, message)
                         raise ValueError(message)
-                    if version == pkg_resources.parse_version(ignore_version):
+                    if version == packaging.version.parse(ignore_version):
                         return None
             else:
                 message = (f"The 'ignore-version' entry in {part_name} is neither a string, "
@@ -182,7 +182,7 @@ class ProcessVersion:
                 raise ValueError(message)
 
         if (("lower-than" in entry_format) and
-                (version >= pkg_resources.parse_version(str(entry_format["lower-than"])))):
+                (version >= packaging.version.parse(str(entry_format["lower-than"])))):
             return None
         if self._checkopt("ignore-odd-minor", entry_format) and ((minor % 2) == 1):
             return None

--- a/updatesnap/unittests.py
+++ b/updatesnap/unittests.py
@@ -403,7 +403,7 @@ class TestYAMLfiles(unittest.TestCase):
 
     def test_version_variation_and_beta_release(self):
         # pylint: disable=protected-access
-        """ Something"""
+        """ tests if a part support version variation and beta-release"""
         obj = ProcessVersion(silent=True)
         obj.set_full_silent()
         data = get_version_variation_and_beta_release()
@@ -830,7 +830,7 @@ def remove_trailing_nls(data):
 
 
 def get_version_variation_and_beta_release():
-    """ Something"""
+    """ returns a list of different types of version-variation and beta release"""
     return [{
         'part_name': 'part1',
         'version': '1.0b2',

--- a/updatesnap/unittests.py
+++ b/updatesnap/unittests.py
@@ -401,6 +401,17 @@ class TestYAMLfiles(unittest.TestCase):
         assert data[0] is None
         assert data[1] is None
 
+    def test_version_variation_and_beta_release(self):
+        # pylint: disable=protected-access
+        """ Something"""
+        obj = ProcessVersion(silent=True)
+        obj.set_full_silent()
+        data = get_version_variation_and_beta_release()
+        for part in data:
+            version = obj._get_version(
+                part['part_name'], part['version'], part['entry_format'], False)
+            assert version is not None
+
 
 class GitPose:
     """ Helper class. It emulates a GitClass class, to allow to test
@@ -816,6 +827,55 @@ def remove_trailing_nls(data):
     while data[-1] == '\n':
         data = data[:-1]
     return data
+
+
+def get_version_variation_and_beta_release():
+    """ Something"""
+    return [{
+        'part_name': 'part1',
+        'version': '1.0b2',
+        'entry_format': {'format': '%V'}
+    }, {
+        'part_name': 'part2',
+        'version': '20240109',
+        'entry_format': {'format': '%V'}
+    }, {
+        'part_name': 'part3',
+        'version': 'debian/3.22.10+dfsg0-4',
+        'entry_format': {'format': 'debian/%V'}
+    }, {
+        'part_name': 'part4',
+        'version': 'debian/0.3-7',
+        'entry_format': {'format': 'debian/%V'}
+    }, {
+        'part_name': 'part5',
+        'version': 'debian/0.8.9-10',
+        'entry_format': {'format': 'debian/%V'}
+    }, {
+        'part_name': 'part6',
+        'version': 'debian/27-11',
+        'entry_format': {'format': 'debian/%V'}
+    }, {
+        'part_name': 'part7',
+        'version': 'debian/20200505dfsg0-2',
+        'entry_format': {'format': 'debian/%V'}
+    }, {
+        'part_name': 'part8',
+        'version': 'debian/1.4+repack0-6',
+        'entry_format': {'format': 'debian/%V'}
+    }, {
+        'part_name': 'part9',
+        'version': 'v6',
+        'entry_format': {'format': 'v%V'}
+    }, {
+        'part_name': 'part10',
+        'version': '3.1a2b3',
+        'entry_format': {'format': '%V'}
+    }, {
+        'part_name': 'part10',
+        'version': '12.0~beta2',
+        'entry_format': {'format': '%V'}
+    }]
 
 
 unittest.main()

--- a/updatesnap/unittests.py
+++ b/updatesnap/unittests.py
@@ -403,7 +403,7 @@ class TestYAMLfiles(unittest.TestCase):
 
     def test_version_variation_and_beta_release(self):
         # pylint: disable=protected-access
-        """ tests if a part support version variation and beta-release"""
+        """ tests if a part support valid version variation and beta-release"""
         obj = ProcessVersion(silent=True)
         obj.set_full_silent()
         data = get_version_variation_and_beta_release()
@@ -411,6 +411,17 @@ class TestYAMLfiles(unittest.TestCase):
             version = obj._get_version(
                 part['part_name'], part['version'], part['entry_format'], False)
             assert version is not None
+
+    def test_invalid_version_variation_and_beta_release(self):
+        # pylint: disable=protected-access
+        """ tests if a part filter out invalid version variation and beta-release"""
+        obj = ProcessVersion(silent=True)
+        obj.set_full_silent()
+        data = get_invalid_version_variation_and_beta_release()
+        for part in data:
+            version = obj._get_version(
+                part['part_name'], part['version'], part['entry_format'], False)
+            assert version is None
 
 
 class GitPose:
@@ -830,7 +841,7 @@ def remove_trailing_nls(data):
 
 
 def get_version_variation_and_beta_release():
-    """ returns a list of different types of version-variation and beta release"""
+    """ returns a list of different types of valid version-variation and beta release"""
     return [{
         'part_name': 'part1',
         'version': '1.0b2',
@@ -875,6 +886,27 @@ def get_version_variation_and_beta_release():
         'part_name': 'part10',
         'version': '12.0~beta2',
         'entry_format': {'format': '%V'}
+    }]
+
+
+def get_invalid_version_variation_and_beta_release():
+    """ returns a list of different types of invalid version-variation and beta release"""
+    return [{
+        'part_name': 'part1',
+        'version': '1.2.3',
+        'entry_format': {'format': 'debian%V'}
+    }, {
+        'part_name': 'part2',
+        'version': '20240109',
+        'entry_format': {'format': 'debian%V'}
+    }, {
+        'part_name': 'part3',
+        'version': 'debian/3.22.10+dfsg0-4',
+        'entry_format': {'format': 'upstream/%V'}
+    }, {
+        'part_name': 'part4',
+        'version': '3.1a2b3',
+        'entry_format': {'format': 'debian%V'}
     }]
 
 


### PR DESCRIPTION
- Implemented support for versions that do not adhere to the PEP 440 standard. PEP 440 dictates that version numbers should follow the format 'N.N[.N]', whereas the example "debian/20200505dfsg0-2" does not comply with this standard.
- This pull request addresses the error/warning captured in the attached screenshot.
<img width="1064" alt="Screenshot 2024-01-11 at 2 11 44 PM" src="https://github.com/ubuntu/desktop-snaps/assets/120119520/326a6b51-7712-4822-9b3a-7d00669daafc">
