### PR TITLE
fix: add suport for tracks in check broken builds

### DIFF
--- a/candidate-snaps-review/check-builds.py
+++ b/candidate-snaps-review/check-builds.py
@@ -70,19 +70,22 @@ def close_issue(n):
       
 # iterate over the list of snaps
 for snapline in snaps.normalsnaps + snaps.specialsnaps:
-    if(snapline[1] != None):
-        response = get_builds(snapline[1].replace("launchpad.net", "api.launchpad.net/1.0")+"/builds")
+    name = snapline[0]
+    url = snapline[1]
+    track = snapline[8]
+    if(url != None):
+        response = get_builds(url.replace("launchpad.net", "api.launchpad.net/1.0")+"/builds")
         for arch, result in response.items():
             # if the snap entry is tracking a specific channel, prepend it
-            if snapline[8]:
-                issue = check_for_issues(snapline[8]+"/"+snapline[0], arch)
+            if track:
+                issue = check_for_issues(track+"/"+name, arch)
             else:
-                issue = check_for_issues(snapline[0], arch)
+                issue = check_for_issues(name, arch)
             if issue != 0 and result:
                 close_issue(issue)
             elif issue == 0 and not result:
                 # if the snap entry is tracking a specific channel, prepend it
-                if snapline[8]:
-                    open_issue(snapline[8]+"/"+snapline[0], arch, snapline[1])
+                if track:
+                    open_issue(track+"/"+name, arch, url)
                 else:
-                    open_issue(snapline[0], arch, snapline[1])
+                    open_issue(name, arch, url)

--- a/candidate-snaps-review/check-builds.py
+++ b/candidate-snaps-review/check-builds.py
@@ -73,8 +73,16 @@ for snapline in snaps.normalsnaps + snaps.specialsnaps:
     if(snapline[1] != None):
         response = get_builds(snapline[1].replace("launchpad.net", "api.launchpad.net/1.0")+"/builds")
         for arch, result in response.items():
-            issue = check_for_issues(snapline[0], arch)
+            # if the snap entry is tracking a specific channel, prepend it
+            if snapline[8]:
+                issue = check_for_issues(snapline[8]+"/"+snapline[0], arch)
+            else:
+                issue = check_for_issues(snapline[0], arch)
             if issue != 0 and result:
                 close_issue(issue)
             elif issue == 0 and not result:
-                open_issue(snapline[0], arch, snapline[1])
+                # if the snap entry is tracking a specific channel, prepend it
+                if snapline[8]:
+                    open_issue(snapline[8]+"/"+snapline[0], arch, snapline[1])
+                else:
+                    open_issue(snapline[0], arch, snapline[1])


### PR DESCRIPTION
A few days ago Ken discovered that the action closed the gaming graphics broken build issue even though it was still broken. This was due to a bug, as the action wasn't taking into account that gaming graphics has three different tracks, and when one of those succeeded building, it closed the issue.
This change prepends the track/channel into the issue name so the action can distinguish between the snaps built on different tracks.