### PR TITLE
[Fixes] git module import error

### DIFF
--- a/.github/workflows/updatesnaptests.yml
+++ b/.github/workflows/updatesnaptests.yml
@@ -26,7 +26,6 @@ jobs:
         python3 -m pip install pyyaml
         python3 -m pip install python-debian
         python3 -m pip install packaging
-        python3 -m pip install gitpython
     - name: Code tests
       env:
         GITHUB_USER: ubuntu

--- a/action.yml
+++ b/action.yml
@@ -41,12 +41,6 @@ runs:
         ref: stable
         path: desktop-snaps
 
-    - name: Install dependencies
-      run: |
-        python3 -m pip install --upgrade pip
-        python3 -m pip install gitpython
-      shell: bash
-
 # Step to run the script that will generate a new output_file with an updated tag, if one is available. If there was a change, then we move this to the snapcraft.yaml and note that there was a change. 
     - name: run updatesnapyaml
       id: updatesnapyaml

--- a/updatesnap/SnapModule/snapmodule.py
+++ b/updatesnap/SnapModule/snapmodule.py
@@ -663,7 +663,7 @@ class Snapcraft(ProcessVersion):
             "missing_format": False,
             "updates": [],
             "version_format": {},
-            "source_url": None,
+            "source_tag": None,
         }
 
         if self._config is None:
@@ -684,6 +684,8 @@ class Snapcraft(ProcessVersion):
             current_tag = data['source-tag']
         else:
             current_tag = None
+
+        part_data['source_tag'] = current_tag
 
         version_format = data['version-format'] if ('version-format' in data) else {}
 
@@ -916,6 +918,8 @@ class Snapcraft(ProcessVersion):
             metadata['upstream-url'] = upstream_data['source_url']
             if len(upstream_data['updates']) != 0:
                 metadata['upstream-version'] = upstream_data['updates'][0]
+            else:
+                metadata['upstream-version'] = upstream_data['source_tag']
 
         if 'grade' in data:
             metadata['grade'] = data['grade']

--- a/updatesnap/SnapModule/snapmodule.py
+++ b/updatesnap/SnapModule/snapmodule.py
@@ -917,7 +917,7 @@ class Snapcraft(ProcessVersion):
             upstream_data = self.process_part(data['adopt-info'])
             metadata['upstream-url'] = upstream_data['source_url']
             if len(upstream_data['updates']) != 0:
-                metadata['upstream-version'] = upstream_data['updates'][0]
+                metadata['upstream-version'] = upstream_data['updates'][0]['name']
             else:
                 metadata['upstream-version'] = upstream_data['source_tag']
 

--- a/updatesnap/SnapVersionModule/snap_version_module.py
+++ b/updatesnap/SnapVersionModule/snap_version_module.py
@@ -4,16 +4,13 @@
     to the package result in an increment of the package release number by 1 """
 
 import subprocess
-import os
-import shutil
 import re
 from datetime import datetime
 import logging
 import requests
-import git
 
 
-def process_snap_version_data(git_repo_url, snap_name, version_schema):
+def process_snap_version_data(upstreamversion, snap_name, version_schema):
     """ Returns processed snap version and grade """
 
     # Time stamp of Snap build in Snap Store
@@ -47,23 +44,7 @@ def process_snap_version_data(git_repo_url, snap_name, version_schema):
         next((channel["version"] for channel in snap_info["channel-map"]
               if channel["channel"]["name"] == "edge"))
     )
-    # Clone the leading upstream repository if it doesn't exist
-    repo_dir = os.path.basename(git_repo_url.rstrip('.git'))
-    if not os.path.exists(repo_dir):
-        try:
-            git.Repo.clone_from(git_repo_url, repo_dir)
-        except git.exc.GitError:
-            logging.warning('Some error occur in cloning leading upstream repo')
-            os.chdir('..')
-            return None
-
-    os.chdir(repo_dir)
-
-    upstreamversion = subprocess.run(["git", "describe", "--tags", "--always"],
-                                     stdout=subprocess.PIPE,
-                                     text=True, check=True).stdout.strip()
-    os.chdir('..')
-    shutil.rmtree(repo_dir)
+    
     match = re.match(version_schema, upstreamversion)
     if not match:
         logging.warning("Version schema does not match with snapping repository version")
@@ -86,10 +67,10 @@ def is_version_update(snap, manager_yaml, arguments):
     if arguments.version_schema == 'None':
         return False
     metadata = snap.process_metadata()
-    if process_snap_version_data(metadata['upstream-url'],
+    if process_snap_version_data(metadata['upstream-version'],
                                  metadata['name'], arguments.version_schema) is not None:
         snap_version = process_snap_version_data(
-            metadata['upstream-url'], metadata['name'], arguments.version_schema)
+            metadata['upstream-version'], metadata['name'], arguments.version_schema)
         if metadata['version'] != snap_version:
             snap_version_data = manager_yaml.get_part_metadata('version')
             if snap_version_data is not None:

--- a/updatesnap/SnapVersionModule/snap_version_module.py
+++ b/updatesnap/SnapVersionModule/snap_version_module.py
@@ -51,7 +51,7 @@ def process_snap_version_data(upstreamversion, snap_name, version_schema):
         return None
     upstreamversion = match.group(1).replace('_', '.')
 
-    if upstreamversion != prevversion.split('-')[0]:
+    if upstreamversion > prevversion.split('-')[0]:
         return f"{upstreamversion}-1"
     # Determine package release number
     packagerelease = int(

--- a/updatesnap/SnapVersionModule/snap_version_module.py
+++ b/updatesnap/SnapVersionModule/snap_version_module.py
@@ -44,7 +44,7 @@ def process_snap_version_data(upstreamversion, snap_name, version_schema):
         next((channel["version"] for channel in snap_info["channel-map"]
               if channel["channel"]["name"] == "edge"))
     )
-    
+
     match = re.match(version_schema, upstreamversion)
     if not match:
         logging.warning("Version schema does not match with snapping repository version")

--- a/updatesnap/unittests.py
+++ b/updatesnap/unittests.py
@@ -437,7 +437,7 @@ class TestYAMLfiles(unittest.TestCase):
             version_schema=r'^gutenprint-(\d+_\d+_\d+)',
         )
         logging.basicConfig(level=logging.ERROR)
-        test = is_version_update(snap, yaml_obj, args)
+        test = is_version_update(snap, yaml_obj, args, has_update=False)
         os.remove('version_file')
         assert test is not None
 
@@ -452,7 +452,7 @@ class TestYAMLfiles(unittest.TestCase):
             version_schema=r'^debian/(\d+\.\d+\.\d+)',
         )
         logging.basicConfig(level=logging.ERROR)
-        test = is_version_update(snap, yaml_obj, args)
+        test = is_version_update(snap, yaml_obj, args, has_update=False)
         assert not test
 
     def test_correct_snap_version(self):
@@ -465,12 +465,13 @@ class TestYAMLfiles(unittest.TestCase):
             version_schema=r'^gutenprint-(\d+_\d+_\d+)',
         )
 
-        def mock_process_version_data(_git_repo_url, _snap_name, _version_schema):
+        def mock_process_version_data(_git_repo_url, _snap_name,
+                                      _version_schema, _has_update=False):
             return "5.3.4-1"
 
         temp = snap_version_module.process_snap_version_data
         snap_version_module.process_snap_version_data = mock_process_version_data
-        test = is_version_update(snap, manager_yaml, args)
+        test = is_version_update(snap, manager_yaml, args, has_update=False)
         snap_version_module.process_snap_version_data = temp
         assert not test
 

--- a/updatesnap/updatesnapyaml.py
+++ b/updatesnap/updatesnapyaml.py
@@ -118,7 +118,7 @@ def main():
         has_update = True
 
     logging.basicConfig(level=logging.INFO)
-    if (is_version_update(snap, manager_yaml, arguments) or has_update):
+    if (is_version_update(snap, manager_yaml, arguments, has_update) or has_update):
         with open('output_file', 'w', encoding="utf8") as output_file:
             output_file.write(manager_yaml.get_yaml())
     else:


### PR DESCRIPTION
Fixes #523 
- It now uses direct source tag / updated source tag to fetch version data of leading upstream data instead of using `'git' `library 