### PR TITLE
[Extend] version-automation to `rockcraft.yaml`

### DIFF
--- a/updatesnap/SnapVersionModule/snap_version_module.py
+++ b/updatesnap/SnapVersionModule/snap_version_module.py
@@ -71,10 +71,6 @@ def process_rock_version_data(upstream_version, previous_version, version_schema
         return None
     upstream_version = match.group(1).replace('_', '.')
 
-    def version_tuple(v):
-        return tuple(map(int, v.split('.')))
-
-    upstream_tuple = version_tuple(upstream_version)
     upstream_tuple = tuple(map(int, upstream_version.split('.')))
     prev_tuple = tuple(map(int, previous_version.split('-')[0].split('.')))
 

--- a/updatesnap/SnapVersionModule/snap_version_module.py
+++ b/updatesnap/SnapVersionModule/snap_version_module.py
@@ -62,30 +62,31 @@ def process_snap_version_data(upstreamversion, snap_name, version_schema, has_up
     return f"{upstreamversion}-{packagerelease}"
 
 
-def process_rock_version_data(upstreamversion, prevversion, version_schema, has_update):
+def process_rock_version_data(upstream_version, previous_version, version_schema, has_update):
     """ Returns processed rock version"""
 
-    match = re.match(version_schema, upstreamversion)
+    match = re.match(version_schema, upstream_version)
     if not match:
         logging.warning("Version schema does not match with rock repository version")
         return None
-    upstreamversion = match.group(1).replace('_', '.')
+    upstream_version = match.group(1).replace('_', '.')
 
     def version_tuple(v):
         return tuple(map(int, v.split('.')))
 
-    upstream_tuple = version_tuple(upstreamversion)
-    prev_tuple = version_tuple(prevversion.split('-')[0])
+    upstream_tuple = version_tuple(upstream_version)
+    upstream_tuple = tuple(map(int, upstream_version.split('.')))
+    prev_tuple = tuple(map(int, previous_version.split('-')[0].split('.')))
 
     if upstream_tuple > prev_tuple:
-        return f"{upstreamversion}-1"
+        return f"{upstream_version}-1"
     # Determine package release number
     if has_update:
-        packagerelease = int(prevversion.split('-')[-1]) + 1
+        packagerelease = int(previous_version.split('-')[-1]) + 1
     else:
-        packagerelease = int(prevversion.split('-')[-1])
+        packagerelease = int(previous_version.split('-')[-1])
 
-    return f"{upstreamversion}-{packagerelease}"
+    return f"{upstream_version}-{packagerelease}"
 
 
 def is_version_update(snap, manager_yaml, arguments, has_update):

--- a/updatesnap/SnapVersionModule/snap_version_module.py
+++ b/updatesnap/SnapVersionModule/snap_version_module.py
@@ -62,6 +62,32 @@ def process_snap_version_data(upstreamversion, snap_name, version_schema, has_up
     return f"{upstreamversion}-{packagerelease}"
 
 
+def process_rock_version_data(upstreamversion, prevversion, version_schema, has_update):
+    """ Returns processed rock version"""
+
+    match = re.match(version_schema, upstreamversion)
+    if not match:
+        logging.warning("Version schema does not match with rock repository version")
+        return None
+    upstreamversion = match.group(1).replace('_', '.')
+
+    def version_tuple(v):
+        return tuple(map(int, v.split('.')))
+
+    upstream_tuple = version_tuple(upstreamversion)
+    prev_tuple = version_tuple(prevversion.split('-')[0])
+
+    if upstream_tuple > prev_tuple:
+        return f"{upstreamversion}-1"
+    # Determine package release number
+    if has_update:
+        packagerelease = int(prevversion.split('-')[-1]) + 1
+    else:
+        packagerelease = int(prevversion.split('-')[-1])
+
+    return f"{upstreamversion}-{packagerelease}"
+
+
 def is_version_update(snap, manager_yaml, arguments, has_update):
     """ Returns if snap version update available """
     has_version_update = False
@@ -85,5 +111,32 @@ def is_version_update(snap, manager_yaml, arguments, has_update):
     if has_version_update:
         with open('version_file', 'w', encoding="utf8") as version_file:
             version_file.write(f"{snap_version}")
+
+    return has_version_update
+
+
+def is_rock_version_update(rock, manager_yaml, arguments, has_update):
+    """ Returns if rock version update available """
+    has_version_update = False
+    if arguments.rock_version_schema == 'None':
+        return False
+    metadata = rock.process_metadata()
+    rock_version = process_rock_version_data(metadata['upstream-version'], metadata['version'],
+                                             arguments.rock_version_schema, has_update)
+    if rock_version is None:
+        return False
+    if metadata['version'] != rock_version:
+        rock_version_data = manager_yaml.get_part_metadata('version')
+        if rock_version_data is not None:
+            logging.info("Updating rock version from %s to %s",
+                         metadata['version'], rock_version)
+            rock_version_data['data'] = f"version: '{rock_version}'"
+            has_version_update = True
+        else:
+            logging.warning("Version is not defined in metadata")
+
+    if has_version_update:
+        with open('version_file', 'w', encoding="utf8") as version_file:
+            version_file.write(f"{rock_version}")
 
     return has_version_update

--- a/updatesnap/updatesnapyaml.py
+++ b/updatesnap/updatesnapyaml.py
@@ -7,7 +7,7 @@ import argparse
 import logging
 from SnapModule.snapmodule import Snapcraft, Github
 from SnapModule.manageYAML import ManageYAML
-from SnapVersionModule.snap_version_module import is_version_update
+from SnapVersionModule.snap_version_module import is_version_update, is_rock_version_update
 UPDATE_BRANCH = 'update_versions'
 
 
@@ -74,6 +74,8 @@ def main():
                         help='Access token for accesing Github projects.')
     parser.add_argument('--version-schema', action='store', default='None',
                         help='Version schema of snapping repository')
+    parser.add_argument('--rock-version-schema', action='store', default='None',
+                        help='Version schema of rock repository')
     parser.add_argument('--verbose', action='store_true', default=False)
     parser.add_argument('project', default='.', help='The project URI')
     arguments = parser.parse_args(sys.argv[1:])
@@ -124,7 +126,8 @@ def main():
         has_update = True
 
     logging.basicConfig(level=logging.INFO)
-    if (is_version_update(snap, manager_yaml, arguments, has_update) or has_update):
+    if (is_version_update(snap, manager_yaml, arguments, has_update) or
+            is_rock_version_update(snap, manager_yaml, arguments, has_update) or has_update):
         with open('output_file', 'w', encoding="utf8") as output_file:
             output_file.write(manager_yaml.get_yaml())
     else:


### PR DESCRIPTION
Extended `desktop-snap` to support `version automation` in `rockraft.yaml` also.

- Users need to define their version schema in `rock-version-schema`, and all other rules will follow as in `snap`, such as:
    - The version should be defined in `metadata`, and the `leading upstream component` should be defined in the `adopt-info` section.
- The automated version format is the same as that of snap `<upstream-version>-<package-release>`.
- When this workflow runs, it checks if there are any updates in the source tag of any part and then updates the version accordingly:
    - If there is a change in the source tag of the leading upstream component, it sets the package release number to 1 and the upstream version to match the leading upstream component.
    - If there is any change in any other source tag, it increments the package release number by 1.