### PR TITLE
Use None instead of string 'None'

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,6 @@ inputs:
   version-schema:
     description: 'Version schema of snapping repository'
     required: false
-    default: 'None'
   rock-version-schema:
     description: 'Version schema of rock repository'
     required: false
@@ -52,7 +51,7 @@ runs:
     - name: run updatesnapyaml
       id: updatesnapyaml
       run: |
-        ./desktop-snaps/updatesnap/updatesnapyaml.py --github-user $GITHUB_USER --github-token $GITHUB_TOKEN --version-schema $VERSION_SCHEMA --rock-version-schema $ROCK_VERSION_SCHEMA ${YAML_PATH:+--yaml-path $YAML_PATH} https://github.com/${{ github.repository }}
+        ./desktop-snaps/updatesnap/updatesnapyaml.py --github-user $GITHUB_USER --github-token $GITHUB_TOKEN ${VERSION_SCHEMA:+--version-schema $VERSION_SCHEMA} ${ROCK_VERSION_SCHEMA:+--rock-version-schema $ROCK_VERSION_SCHEMA} ${YAML_PATH:+--yaml-path $YAML_PATH} https://github.com/${{ github.repository }}
         # Make sure to put the updated snapcraft.yaml file in the right location if it lives in a snap directory
         if [ -f version_file ]; then
           echo "IS_VERSION_CHANGE=true" >> $GITHUB_ENV

--- a/updatesnap/SnapVersionModule/snap_version_module.py
+++ b/updatesnap/SnapVersionModule/snap_version_module.py
@@ -88,7 +88,7 @@ def process_rock_version_data(upstream_version, previous_version, version_schema
 def is_version_update(snap, manager_yaml, arguments, has_update):
     """ Returns if snap version update available """
     has_version_update = False
-    if arguments.version_schema == 'None':
+    if arguments.version_schema is None:
         return False
     metadata = snap.process_metadata()
     if process_snap_version_data(metadata['upstream-version'], metadata['name'],
@@ -115,7 +115,7 @@ def is_version_update(snap, manager_yaml, arguments, has_update):
 def is_rock_version_update(rock, manager_yaml, arguments, has_update):
     """ Returns if rock version update available """
     has_version_update = False
-    if arguments.rock_version_schema == 'None':
+    if arguments.rock_version_schema is None:
         return False
     metadata = rock.process_metadata()
     rock_version = process_rock_version_data(metadata['upstream-version'], metadata['version'],

--- a/updatesnap/updatesnapyaml.py
+++ b/updatesnap/updatesnapyaml.py
@@ -79,9 +79,9 @@ def main():
                         help='User name for accessing Github projects.')
     parser.add_argument('--github-token', action='store', default=None,
                         help='Access token for accessing Github projects.')
-    parser.add_argument('--version-schema', action='store', default='None',
+    parser.add_argument('--version-schema', action='store', default=None,
                         help='Version schema of snapping repository')
-    parser.add_argument('--rock-version-schema', action='store', default='None',
+    parser.add_argument('--rock-version-schema', action='store', default=None,
                         help='Version schema of rock repository')
     parser.add_argument('--yaml-path', action='store', default=None,
                         help='Path to the yaml file')


### PR DESCRIPTION
Two command line options use the string 'None' instead of the native type None as the default value.

This PR changes this.