### PR TITLE
Fix Handling of snapcraft.yaml and rockcraft.yaml in the Same Directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,8 +62,6 @@ runs:
           echo "IS_CHANGE=true" >> $GITHUB_ENV
           if [ -n "$YAML_PATH" ]; then
             mv output_file $YAML_PATH
-          elif [ -f rockcraft.yaml ]; then
-            mv output_file rockcraft.yaml
           elif [ -d snap ]; then
             mv output_file snap/snapcraft.yaml
           else

--- a/updatesnap/updatesnapyaml.py
+++ b/updatesnap/updatesnapyaml.py
@@ -61,12 +61,6 @@ class ProjectManager:
                 data = self._github.get_file(project_url, yaml_path)
             except (ValueError, ConnectionError):
                 data = None
-        if not data:
-            yaml_path = 'rockcraft.yaml'
-            try:
-                data = self._github.get_file(project_url, yaml_path)
-            except (ValueError, ConnectionError):
-                data = None
         return data
 
 


### PR DESCRIPTION
Previously, having both snapcraft.yaml and rockcraft.yaml in the same directory caused snapcraft.yaml to be automatically converted to rockcraft.yaml.

This PR fixes the issue by requiring explicit use of the `--yaml-path` argument to update rockcraft.yaml (e.g., `--yaml-path: rockcraft.yaml`).

This ensures no unintended behavior when both files are present.