### PR TITLE
abi_breaker: Fix path replacement bug using relative paths

### DIFF
--- a/abi-breaks/abi_breaker.py
+++ b/abi-breaks/abi_breaker.py
@@ -230,7 +230,8 @@ class SnapComparer(Colors):
             for root, _, files in os.walk(old_path):
                 for filename in files:
                     full_old_path = os.path.join(root, filename)
-                    full_new_path = full_old_path.replace(old_path, new_path)
+                    rel_path = os.path.relpath(full_old_path, old_path)
+                    full_new_path = os.path.join(new_path, rel_path)
                     if not self._should_check(full_old_path, full_new_path):
                         continue
                     self._do_comparison(full_old_path, full_new_path, show_new_symbols)


### PR DESCRIPTION
## Summary of Changes
Fixes a path-manipulation bug in `abi_breaker.py` where `full_old_path.replace(old_path, new_path)` corrupts target paths if substring matches occur earlier in the directory hierarchy.

## Problem
When directory structures share common substring names with `old_path`, `str.replace()` replaces unintended string segments, causing `full_new_path` to resolve to non-existent file locations.

## Solution
Replaced `str.replace()` with standard library path functions:
```python
rel_path = os.path.relpath(full_old_path, old_path)
full_new_path = os.path.join(new_path, rel_path)